### PR TITLE
Standardize on four-column tab indents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# Explanation of this file: https://editorconfig.org
+# Style per
+# https://github.com/ronsavage/Regexp-Assemble/pull/8#issuecomment-605718707
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+insert_final_newline = true
+
+# Test files with mixed indents: editor should not enforce indent style
+[t/{03_str.t,t/09_debug.t}]
+indent_style = unset
+
+# Input files with special formats
+[examples/file.4]
+insert_final_newline = false

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ nytprof.out
 *.bs
 /_eumm/
 /Regexp-Assemble-*
+*.swp
+*~
+~*

--- a/Changelog.ini
+++ b/Changelog.ini
@@ -1,32 +1,34 @@
 [Module]
 Name=Regexp::Assemble
 Changelog.Creator=Module::Metadata::Changes V 2.12
-Changelog.Parser=Config::IniFiles V 2.94
+Changelog.Parser=Config::IniFiles V 3.000001
 
 [V 0.38]
 Date=2017-06-20T08:51:00
 Comments= <<EOT
 - Fix test prereqs; pod tests moved to xt (RT#122136, RT#122137)
 Many thanx to Karen Etheridge for these patches.
-Note: I (Ron) have no idea where the version 2.07 originally comes from, although I have
-seen it before. It was not in the very first distro I got my hands on. Anyway, I've
-reverted Karen's patch to 0.38 to match the current sequence of version #s. Apart from
-that, all these fine improvements are hers. If this version # causes difficulties, I'll
-just bump it to 2.08.
+Note: I (Ron) have no idea where the version 2.07 originally comes from,
+although I have seen it before. It was not in the very first distro I got
+my hands on. Anyway, I've reverted Karen's patch to 0.38 to match the
+current sequence of version #s. Apart from that, all these fine
+improvements are hers. If this version # causes difficulties, I'll just
+bump it to 2.08.
 - Adopt new repo structure. For details, see
-http://savage.net.au/Ron/html/My.Workflow.for.Building.Distros.html. Specifically:
+http://savage.net.au/Ron/html/My.Workflow.for.Building.Distros.html.
+Specifically:
 o Delete MANIFEST and META.yml, and hereafter auto-generate them.
 o Modernize .gitignore and MANIFEST.SKIP.
-o The code says Perl licence but the LICENCE file says Artistic, so replace LICENCE file
-with LICENSE (so spelled), which says Perl.
+o The code says Perl licence but the LICENCE file says Artistic, so
+replace LICENCE file with LICENSE (so spelled), which says Perl.
 EOT
 
 [V 0.37]
 Date=2016-04-18T08:51:00
 Comments= <<EOT
 - No code changes.
-- Accept pull request from monsieurp to add a LICENCE (sic, see below) file. With thanx.
-This activity is part of the CPAN PR Challenge 2016.
+- Accept pull request from monsieurp to add a LICENCE (sic, see below)
+file. With thanx. This activity is part of the CPAN PR Challenge 2016.
 - Update MANIFEST to include LICENCE file.
 - Remove unicode characters from Changes and Changelog.ini files.
 - Add TODO and update MANIFEST to note unicode issues.
@@ -38,21 +40,23 @@ Date=2015-08-16T11:34:00
 Comments= <<EOT
 - Ron Savage is now co-maint.
 - Move eg/ to examples/.
-- Many thanx to the various parties who logged issues on RT. Some have been fixed, see below.
+- Many thanx to the various parties who logged issues on RT. Some have been
+fixed, see below.
 - Add examples/failure.01.pl, downloaded, and noted in docs, from
 https://rt.cpan.org/Public/Bug/Display.html?id=104897
 - Move pod tests into xt/author/pod.t by cutting them out of t/00_basic.t.
 See https://rt.cpan.org/Public/Bug/Display.html?id=85686
 and https://rt.cpan.org/Public/Bug/Display.html?id=85209
 - Add repository https://github.com/ronsavage/Regexp-Assemble.git.
-Note: github does not list Perl as one of the licence options, so the auto-generated
-LICENSE (sic) file is not included in the distro.
+Note: github does not list Perl as one of the licence options, so the
+auto-generated LICENSE (sic) file is not included in the distro.
 See https://rt.cpan.org/Public/Bug/Display.html?id=103856.
 - Fix some spelling errors in the pod.
 See https://rt.cpan.org/Public/Bug/Display.html?id=84336
 - Move ./Assemble.pm into lib/Regexp/.
 - Move the contents of the TODO file into the docs, and delete that file.
-- Rearrange pod, but not be running this module over it :-). Actually, put pod at end of file.
+- Rearrange pod, but not be running this module over it :-). Actually, put
+pod at end of file.
 - Update Makefile.PL.
 - Add Changelog.ini.
 - Update MANIFEST.SKIP.

--- a/Changes
+++ b/Changes
@@ -2,23 +2,25 @@ Revision history for Perl extension Regexp::Assemble.
 
 0.38  2017-06-20T08:51:00
 	- Fix test prereqs; pod tests moved to xt (RT#122136, RT#122137)
-		Many thanx to Karen Etheridge for these patches.
-		Note: I (Ron) have no idea where the version 2.07 originally comes from, although I have
-		seen it before. It was not in the very first distro I got my hands on. Anyway, I've
-		reverted Karen's patch to 0.38 to match the current sequence of version #s. Apart from
-		that, all these fine improvements are hers. If this version # causes difficulties, I'll
-		just bump it to 2.08.
+	  Many thanx to Karen Etheridge for these patches.
+	  Note: I (Ron) have no idea where the version 2.07 originally comes from,
+	  although I have seen it before. It was not in the very first distro I got
+	  my hands on. Anyway, I've reverted Karen's patch to 0.38 to match the
+	  current sequence of version #s. Apart from that, all these fine
+	  improvements are hers. If this version # causes difficulties, I'll just
+	  bump it to 2.08.
 	- Adopt new repo structure. For details, see
-		http://savage.net.au/Ron/html/My.Workflow.for.Building.Distros.html. Specifically:
+	  http://savage.net.au/Ron/html/My.Workflow.for.Building.Distros.html.
+	  Specifically:
 		o Delete MANIFEST and META.yml, and hereafter auto-generate them.
 		o Modernize .gitignore and MANIFEST.SKIP.
-		o The code says Perl licence but the LICENCE file says Artistic, so replace LICENCE file
-			with LICENSE (so spelled), which says Perl.
+		o The code says Perl licence but the LICENCE file says Artistic, so
+		  replace LICENCE file with LICENSE (so spelled), which says Perl.
 
 0.37  2016-04-18T08:51:00
 	- No code changes.
-	- Accept pull request from monsieurp to add a LICENCE (sic, see below) file. With thanx.
-		This activity is part of the CPAN PR Challenge 2016.
+	- Accept pull request from monsieurp to add a LICENCE (sic, see below)
+	  file. With thanx.  This activity is part of the CPAN PR Challenge 2016.
 	- Update MANIFEST to include LICENCE file.
 	- Remove unicode characters from Changes and Changelog.ini files.
 	- Add TODO and update MANIFEST to note unicode issues.
@@ -27,437 +29,439 @@ Revision history for Perl extension Regexp::Assemble.
 0.36 2015-08-16T11:34:00
 	- Ron Savage is now co-maint.
 	- Move eg/ to examples/.
-	- Many thanx to the various parties who logged issues on RT. Some have been fixed, see below.
+	- Many thanx to the various parties who logged issues on RT. Some have been
+	  fixed, see below.
 	- Add examples/failure.01.pl, downloaded, and noted in docs, from
-		https://rt.cpan.org/Public/Bug/Display.html?id=104897
+	  https://rt.cpan.org/Public/Bug/Display.html?id=104897
 	- Move pod tests into xt/author/pod.t by cutting them out of t/00_basic.t.
-		See https://rt.cpan.org/Public/Bug/Display.html?id=85686
-		and https://rt.cpan.org/Public/Bug/Display.html?id=85209
+	  See https://rt.cpan.org/Public/Bug/Display.html?id=85686
+	  and https://rt.cpan.org/Public/Bug/Display.html?id=85209
 	- Add repository https://github.com/ronsavage/Regexp-Assemble.git.
-		Note: github does not list Perl as one of the licence options, so the auto-generated
-		LICENSE (sic) file is not included in the distro.
-		See https://rt.cpan.org/Public/Bug/Display.html?id=103856.
+	  Note: github does not list Perl as one of the licence options, so the
+	  auto-generated LICENSE (sic) file is not included in the distro.
+	  See https://rt.cpan.org/Public/Bug/Display.html?id=103856.
 	- Fix some spelling errors in the pod.
-		See https://rt.cpan.org/Public/Bug/Display.html?id=84336
+	  See https://rt.cpan.org/Public/Bug/Display.html?id=84336
 	- Move ./Assemble.pm into lib/Regexp/.
 	- Move the contents of the TODO file into the docs, and delete that file.
-	- Rearrange pod, but not be running this module over it :-). Actually, put pod at end of file.
+	- Rearrange pod, but not be running this module over it :-). Actually, put
+	  pod at end of file.
 	- Update Makefile.PL.
 	- Add Changelog.ini.
 	- Update MANIFEST.SKIP.
 
 0.35 2011-04-07 13:18:48 UTC
-    - Update test suite to take into account the regexp
-      engine changes for 5.14. No functional differences.
+	- Update test suite to take into account the regexp
+	  engine changes for 5.14. No functional differences.
 
 0.34 2008-06-17 20:20:14 UTC
-    - Rewrite the usage of _re_sort() in order to deal
-      with blead change #33874. Bug smoked out by Andreas
-      Konig.
+	- Rewrite the usage of _re_sort() in order to deal
+	  with blead change #33874. Bug smoked out by Andreas
+	  Konig.
 
 0.33 2008-06-07 14:40:57 UTC
-    - Tweaked _fastlex() to fix bug #36399 spotted by Yves
-      Blusseau ('a|[bc]' becomes 'a\|[bc]').
-    - Recognise POSIX character classes (e.g. [[:alpha:]].
-      Bug also spotted by Yves Blusseau (bug #36465).
+	- Tweaked _fastlex() to fix bug #36399 spotted by Yves
+	  Blusseau ('a|[bc]' becomes 'a\|[bc]').
+	- Recognise POSIX character classes (e.g. [[:alpha:]].
+	  Bug also spotted by Yves Blusseau (bug #36465).
 
 0.32 2007-07-30 17:47:39 UTC
-    - Backed out the change introduced in 0.25 (that created
-      slimmer regexps when custom flags are used). As things
-      stood, it meant that '/' could not appear in a pattern
-      with flags (and could possibly dump core). Bug #28554
-      noted by David Morel.
-    - Allow a+b to be unrolled into aa*b, as that may allow
-      further reductions (bug #20847 noted by Philippe Bruhat).
-      Not completely implemented, but bug #28554 is sufficient
-      to push out a new release.
-    - eg/assemble understands -U to enable plus unrollings.
-    - Extended campaign of coverage improvements made to the
-      test suite caught a minor flaw in source().
+	- Backed out the change introduced in 0.25 (that created
+	  slimmer regexps when custom flags are used). As things
+	  stood, it meant that '/' could not appear in a pattern
+	  with flags (and could possibly dump core). Bug #28554
+	  noted by David Morel.
+	- Allow a+b to be unrolled into aa*b, as that may allow
+	  further reductions (bug #20847 noted by Philippe Bruhat).
+	  Not completely implemented, but bug #28554 is sufficient
+	  to push out a new release.
+	- eg/assemble understands -U to enable plus unrollings.
+	- Extended campaign of coverage improvements made to the
+	  test suite caught a minor flaw in source().
 
 0.31 2007-06-04 20:40:33 UTC
-    - Add a fold_meta_pairs flag to control the behaviour of
-      [\S\s] (and [\D\d], [\W\w]) being folded to '.' (bug
-      #24171 spotted by Philippe Bruhat).
+	- Add a fold_meta_pairs flag to control the behaviour of
+	  [\S\s] (and [\D\d], [\W\w]) being folded to '.' (bug
+	  #24171 spotted by Philippe Bruhat).
 
 0.30 2007-05-18 15:39:37 UTC
-    - Fixup _fastlex() bug in 5.6 (unable to discriminate \cX).
-      This allows bug #27138 to be closed.
+	- Fixup _fastlex() bug in 5.6 (unable to discriminate \cX).
+	  This allows bug #27138 to be closed.
 
 0.29 2007-05-17 10:48:42 UTC
-    - Tracked patterns enhanced to take advantage of 5.10
-      (and works again with blead).
-    - The mutable() functionality has been marked as
-      deprecated.
-    - mailing list web page was incorrect (noted by Kai
-      Carver)
+	- Tracked patterns enhanced to take advantage of 5.10
+	  (and works again with blead).
+	- The mutable() functionality has been marked as
+	  deprecated.
+	- mailing list web page was incorrect (noted by Kai
+	  Carver)
 
 0.28 2006-11-26 21:49:26 UTC
-    - Fixed a.+ bug (interpreted as a\.+) (bug #23623)
-    - Handle /[a]/ => /a/
+	- Fixed a.+ bug (interpreted as a\.+) (bug #23623)
+	- Handle /[a]/ => /a/
 
 0.27 2006-11-01 23:43:35 UTC
-    - rewrote the lexing of patterns in _fastlex(). Unfortunately
-      this doesn't speed things up as much as I had hoped.
-    - eg/assemble now recognises -T to dump timing statistics.
-    - file parameter in add_file() may accept a single scalar
-      (or a list, as before).
-    - rs parameter in new() was not recognised as an alias
-      for input_record_separator,
-    - anchor_string_absolute as a parameter to new() would not
-      have worked correctly.
-    - a couple of anchor_<mumble>() methods would not have
-      worked correctly.
-    - Added MANIFEST.SKIP, now that the module is under
-      version control.
-    - Broke out the debug tests into a separate file
-      (t/09_debug.t).
-    - cmp_ok() tests that tested equality were replaced by is().
-    - tests in t/03_str.t transformed to a data-driven approach,
-      in order to slim down the size of the distribution tarball.
-    - Typo spotted in the documentation by Stephan (bug #20425).
+	- rewrote the lexing of patterns in _fastlex(). Unfortunately
+	  this doesn't speed things up as much as I had hoped.
+	- eg/assemble now recognises -T to dump timing statistics.
+	- file parameter in add_file() may accept a single scalar
+	  (or a list, as before).
+	- rs parameter in new() was not recognised as an alias
+	  for input_record_separator,
+	- anchor_string_absolute as a parameter to new() would not
+	  have worked correctly.
+	- a couple of anchor_<mumble>() methods would not have
+	  worked correctly.
+	- Added MANIFEST.SKIP, now that the module is under
+	  version control.
+	- Broke out the debug tests into a separate file
+	  (t/09_debug.t).
+	- cmp_ok() tests that tested equality were replaced by is().
+	- tests in t/03_str.t transformed to a data-driven approach,
+	  in order to slim down the size of the distribution tarball.
+	- Typo spotted in the documentation by Stephan (bug #20425).
 
 0.26 2006-07-12 09:27:51 UTC
-    - Incorporated a patch to the test suite from barbie, to work
-      around a problem encountered on Win32 (bug #17507).
-    - The "match nothing" pattern was incorrect (but so obscure
-      as to be reasonably safe).
-    - Removed the unguarded tests in t/06_general.t that the
-      Test::More workaround in 0.24 skips.
-    - Newer versions of Sub::Uplevel no longer need to be guarded
-      against in t/07_warning.t.
+	- Incorporated a patch to the test suite from barbie, to work
+	  around a problem encountered on Win32 (bug #17507).
+	- The "match nothing" pattern was incorrect (but so obscure
+	  as to be reasonably safe).
+	- Removed the unguarded tests in t/06_general.t that the
+	  Test::More workaround in 0.24 skips.
+	- Newer versions of Sub::Uplevel no longer need to be guarded
+	  against in t/07_warning.t.
 
 0.25 2006-04-20 18:04:49
-    - Added a debug switch to elapsed pattern insertion and
-      pattern reduction times. Upgraded eg/assemble to make
-      use of it.
-    - Tweaked the resulting pattern when it uses 'imsx'
-      flags, giving (?i-xsm:(?:^a[bc]|de)) instead of
-      (?-xism:(?i:(?:^a[bc]|de))) .
-    - Changed the "match nothing" pattern to something slightly
-      less unsurprising to those who peek behind the curtain.
-      Reported by Philippe Bruhat (bug #18266).
-    - Tweaked the dump() output for chars \x00 .. \x1f
+	- Added a debug switch to elapsed pattern insertion and
+	  pattern reduction times. Upgraded eg/assemble to make
+	  use of it.
+	- Tweaked the resulting pattern when it uses 'imsx'
+	  flags, giving (?i-xsm:(?:^a[bc]|de)) instead of
+	  (?-xism:(?i:(?:^a[bc]|de))) .
+	- Changed the "match nothing" pattern to something slightly
+	  less unsurprising to those who peek behind the curtain.
+	  Reported by Philippe Bruhat (bug #18266).
+	- Tweaked the dump() output for chars \x00 .. \x1f
 
 0.24 2006-03-21 08:50:42
-    - Added an add_file() method that allows a file of patterns to
-      be slurped into an object. Makes for less make-work code in
-      the client code (and thus one less thing to go wrong there).
-    - Added anchor methods that tack on \b, ^, $ and the like to an
-      assembled pattern.
-    - Rewrote new() and clone(). The latter is now no longer needs
-      to know the attribute names.
-    - _lex_stateful() subsumed into _lex()
-    - \d and \w assemble to \w instead of [\w\d] (and similarly for
-      \D and \W).
-    - The Test::More workaround stated in the 0.23 changes didn't
-      actually make it into t/06_general.t
-    - Rewrote tests in 06_general.t to use like()/unlike() instead
-      of ok(), and some more ok()'s replaced by cmp_ok()
-      elsewhere.
-    - Diagnostics for t/00_basic.t:xcmp was incorrect (displayed
-      first param instead of second).
-    - Guard against broken Sub::Uplevel in t/07_warning.t for
-      perl 5.8.8.
-    - Pretty-print characters [\x00-\x1f] in _dump() routines.
-    - Spell-checked the POD!
+	- Added an add_file() method that allows a file of patterns to
+	  be slurped into an object. Makes for less make-work code in
+	  the client code (and thus one less thing to go wrong there).
+	- Added anchor methods that tack on \b, ^, $ and the like to an
+	  assembled pattern.
+	- Rewrote new() and clone(). The latter is now no longer needs
+	  to know the attribute names.
+	- _lex_stateful() subsumed into _lex()
+	- \d and \w assemble to \w instead of [\w\d] (and similarly for
+	  \D and \W).
+	- The Test::More workaround stated in the 0.23 changes didn't
+	  actually make it into t/06_general.t
+	- Rewrote tests in 06_general.t to use like()/unlike() instead
+	  of ok(), and some more ok()'s replaced by cmp_ok()
+	  elsewhere.
+	- Diagnostics for t/00_basic.t:xcmp was incorrect (displayed
+	  first param instead of second).
+	- Guard against broken Sub::Uplevel in t/07_warning.t for
+	  perl 5.8.8.
+	- Pretty-print characters [\x00-\x1f] in _dump() routines.
+	- Spell-checked the POD!
 
 0.23 2006-01-03 17:03:35
-    - More bugs in the reduction code shaken out by examining
-      powersets. Exhaustive testing (iterating through the
-      powerset of a, b, c, d, e) makes me think that the
-      pathological cases are taken care of. The code is horrible,
-      though, a rewrite is next on the agenda.
-    - Guard against earlier buggy versions of Test::More (0.47)
-      in t/06_general.t
-    - Carp::croak rewritten as Carp::croak() to fix failures
-      noted on blead.
-    - Rewrote _re_path() for speed.
-    - added lexstr() routine.
-    - added eg/stress-test program.
+	- More bugs in the reduction code shaken out by examining
+	  powersets. Exhaustive testing (iterating through the
+	  powerset of a, b, c, d, e) makes me think that the
+	  pathological cases are taken care of. The code is horrible,
+	  though, a rewrite is next on the agenda.
+	- Guard against earlier buggy versions of Test::More (0.47)
+	  in t/06_general.t
+	- Carp::croak rewritten as Carp::croak() to fix failures
+	  noted on blead.
+	- Rewrote _re_path() for speed.
+	- added lexstr() routine.
+	- added eg/stress-test program.
 
 0.22 2005-12-02 11:31:42 UTC
-    - Amended the test suite to ensure that it runsh0orrectly under
-      5.005_04. (The documentation was updated to reflect the
-      limitations). Sbastien Aperghis-Tramoni provided the impetus
-      for this fix. No other changes in functionality.
-    - The SKIP counts in t/06_general.t were out of whack for 5.6
-      and 5.005 testing.
+	- Amended the test suite to ensure that it runsh0orrectly under
+	  5.005_04. (The documentation was updated to reflect the
+	  limitations). Sbastien Aperghis-Tramoni provided the impetus
+	  for this fix. No other changes in functionality.
+	- The SKIP counts in t/06_general.t were out of whack for 5.6
+	  and 5.005 testing.
 
 0.21 2005-11-26 16:16:06 UTC
-    - Fixed a nasty bug after generating a series of lists of
-      patterns using Data::PowerSet: ^abc$ ^abcd$ ^ac$ ^acd$ ^b$
-      ^bc$ ^bcd$ ^bd$ would produce the incorrect
-      ^b(?:(?:ab?)?c)?d?$ pattern. It should if fact produce the
-      ^(?:ab?c|bc?)d?$ pattern.
-    - Improve the reduction of, for example, 'sing', 'singing',
-      'sting'. In prior versions this would produce
-      s(?:ing(?:ing)?|ting), now it produces s(?:(?:ing)?|t)ing.
-      The code is a bit horrendous (especially the part at the end
-      of _reduce_path). And it's still not perfect. See the TODO.
-    - Duplicate pattern detection wasn't quite right.  The code
-      was lacking an else clause, which meant 'abcdef' followed by
-      'abc' would have the latter treated as a duplicate.
-    - Now that there's a statistic that keeps track of when a
-      duplicate input pattern was encountered, it becomes possible
-      to let the user know about it. Two possibilities are available:
-      a simple carp(), or a callback for complete control.  The first
-      time I tried this out on a real file of 3558 patterns, it found
-      9 dups (or rather, 8 dups and a bug in the module).
-    - The above improvement means the test suite now requires
-      Test::Warn. As a result, t/07_pod.t was subsumed into
-      t/00_basic.t and t/07_warning.t was born.
-    - Added an eg/ircwatcher script that demonstrates how to set up a
-      dispatch table on a tracked regular expression. Credit to David
-      Rigaudiere for the idea.
-    - Made sure all routines use an explicit return when it makes
-      sense to do so. (I have a tendency to use implicit returns,
-      which is evil).
-    - the Carp module is require'ed on an on-demand basis.
-    - eg/naive updated to bring its idea of $Single_Char in line with
-      Assemble.pm.
-    - Cleaned up typos and PODos in the documentation.  Fixed minor
-      typo noted by David Rigaudiere.
-    - Reworked as_string() and re() to play nicely with Devel::Cover,
-      but alas, the module no longer runs under D::C at all. Something
-      to do with the overloading of "" for re()?
+	- Fixed a nasty bug after generating a series of lists of
+	  patterns using Data::PowerSet: ^abc$ ^abcd$ ^ac$ ^acd$ ^b$
+	  ^bc$ ^bcd$ ^bd$ would produce the incorrect
+	  ^b(?:(?:ab?)?c)?d?$ pattern. It should if fact produce the
+	  ^(?:ab?c|bc?)d?$ pattern.
+	- Improve the reduction of, for example, 'sing', 'singing',
+	  'sting'. In prior versions this would produce
+	  s(?:ing(?:ing)?|ting), now it produces s(?:(?:ing)?|t)ing.
+	  The code is a bit horrendous (especially the part at the end
+	  of _reduce_path). And it's still not perfect. See the TODO.
+	- Duplicate pattern detection wasn't quite right.  The code
+	  was lacking an else clause, which meant 'abcdef' followed by
+	  'abc' would have the latter treated as a duplicate.
+	- Now that there's a statistic that keeps track of when a
+	  duplicate input pattern was encountered, it becomes possible
+	  to let the user know about it. Two possibilities are available:
+	  a simple carp(), or a callback for complete control.  The first
+	  time I tried this out on a real file of 3558 patterns, it found
+	  9 dups (or rather, 8 dups and a bug in the module).
+	- The above improvement means the test suite now requires
+	  Test::Warn. As a result, t/07_pod.t was subsumed into
+	  t/00_basic.t and t/07_warning.t was born.
+	- Added an eg/ircwatcher script that demonstrates how to set up a
+	  dispatch table on a tracked regular expression. Credit to David
+	  Rigaudiere for the idea.
+	- Made sure all routines use an explicit return when it makes
+	  sense to do so. (I have a tendency to use implicit returns,
+	  which is evil).
+	- the Carp module is require'ed on an on-demand basis.
+	- eg/naive updated to bring its idea of $Single_Char in line with
+	  Assemble.pm.
+	- Cleaned up typos and PODos in the documentation.  Fixed minor
+	  typo noted by David Rigaudiere.
+	- Reworked as_string() and re() to play nicely with Devel::Cover,
+	  but alas, the module no longer runs under D::C at all. Something
+	  to do with the overloading of "" for re()?
 
 0.20 2005-11-07 18:03:32 UTC
-    - Fixed long-standing indent bug:
-      $ra->add( 'a\.b' )->add( 'a-b' )->as_string(indent=>2)
-      ... would produce a(?:\.|-b) instead of a[-.]b.
-    - Fixed bug ($ and ^ not treated correctly). See RT ticket
-      #15522. Basically, '^a' and 'ma' produced [m^]a instead
-      of (?:^|m)a
-    - Statistics! See the stats_* methods.
-    - eg/assemble now has an -s switch to display these
-      statistics
-    - Minor tweak to t/02_reduce.t to get it to play nicely
-      with Devel::Cover.
-    - t/02_reduce.t had an unnecessary use Data::Dumper.
+	- Fixed long-standing indent bug:
+	  $ra->add( 'a\.b' )->add( 'a-b' )->as_string(indent=>2)
+	  ... would produce a(?:\.|-b) instead of a[-.]b.
+	- Fixed bug ($ and ^ not treated correctly). See RT ticket
+	  #15522. Basically, '^a' and 'ma' produced [m^]a instead
+	  of (?:^|m)a
+	- Statistics! See the stats_* methods.
+	- eg/assemble now has an -s switch to display these
+	  statistics
+	- Minor tweak to t/02_reduce.t to get it to play nicely
+	  with Devel::Cover.
+	- t/02_reduce.t had an unnecessary use Data::Dumper.
 
 0.19 2005-11-02 15:16:16 UTC
-    - Change croaking diagnostic concerning Default_Lexer.
-      Bug spotted by barbie in ticket #15044.
-    - Pointer to C<Tree::Trie> in the documentation.
-    - Excised Test::Deep probe in 00_basic.t, since the
-      module is no longer used.
-    - Detabbed eg/*
+	- Change croaking diagnostic concerning Default_Lexer.
+	  Bug spotted by barbie in ticket #15044.
+	- Pointer to C<Tree::Trie> in the documentation.
+	- Excised Test::Deep probe in 00_basic.t, since the
+	  module is no longer used.
+	- Detabbed eg/*
 
 0.18 2005-10-08 20:37:53 UTC
-    - Fixed '\Q[' to be as treated as '\[' instead of '['.
-      What's more, the tests had this as the Right Thing.
-      What was I thinking? Wound up rewriting _lex_stateful
-      in a much less hairier way, even though it now uses
-      gotos.
-    - Introduced a context hash for dragging around the bits
-      and pieces required by the descent into _reduce_path.
-      It doesn't really help much right now, but is vital for
-      solving the qw(be by my me) => /[bm][ey]/ problem. See
-      TODO for more notes.
-    - Fixed the debug output to play nicely with the test
-      harness (by prefixing everything with a #). It had never
-      been a problem, but you never know.
-    - Added a script named 'debugging' to help people figure
-      out why assembled patterns go wonky (which is invariably
-      due to nested parentheses).
-    - Added a script 'tld', that produces a regexp for
-      matching internet Top Level Domain names. This happens to
-      be an ideal example of showing how the alternations are
-      sorted.
-    - Added a script 'roman', that produces a regexp for
-      matching Roman numerals. Just for fun.
-    - Removed the 'assemble-check' script, whose functionality
-      is adequately dealt with via 'assemble -t'.
-    - Tightened up the explanation of why tracked patterns are
-      bulkier
-    - ISOfied the dates in this file.
+	- Fixed '\Q[' to be as treated as '\[' instead of '['.
+	  What's more, the tests had this as the Right Thing.
+	  What was I thinking? Wound up rewriting _lex_stateful
+	  in a much less hairier way, even though it now uses
+	  gotos.
+	- Introduced a context hash for dragging around the bits
+	  and pieces required by the descent into _reduce_path.
+	  It doesn't really help much right now, but is vital for
+	  solving the qw(be by my me) => /[bm][ey]/ problem. See
+	  TODO for more notes.
+	- Fixed the debug output to play nicely with the test
+	  harness (by prefixing everything with a #). It had never
+	  been a problem, but you never know.
+	- Added a script named 'debugging' to help people figure
+	  out why assembled patterns go wonky (which is invariably
+	  due to nested parentheses).
+	- Added a script 'tld', that produces a regexp for
+	  matching internet Top Level Domain names. This happens to
+	  be an ideal example of showing how the alternations are
+	  sorted.
+	- Added a script 'roman', that produces a regexp for
+	  matching Roman numerals. Just for fun.
+	- Removed the 'assemble-check' script, whose functionality
+	  is adequately dealt with via 'assemble -t'.
+	- Tightened up the explanation of why tracked patterns are
+	  bulkier
+	- ISOfied the dates in this file.
 
 0.17 2005-09-10 16:41:22 UTC
-    - Add capture() method.
-    - Restructure _insert_path().
-    - Factor out duplicated code introduced in 0.16 into
-      _build_re().
-    - Ensure that the test suite exercises the fallback
-      code path for when Storable is missing, even if
-      Storable is available.
-    - Added test_pod_coverage, merely to earn a free
-      Kwalitee point.
+	- Add capture() method.
+	- Restructure _insert_path().
+	- Factor out duplicated code introduced in 0.16 into
+	  _build_re().
+	- Ensure that the test suite exercises the fallback
+	  code path for when Storable is missing, even if
+	  Storable is available.
+	- Added test_pod_coverage, merely to earn a free
+	  Kwalitee point.
 
 0.16 2005-08-22 23:04:02 UTC
-    - Tracked patterns silently ignored imsx flags. Spotted by
-      Bart Lateur.
+	- Tracked patterns silently ignored imsx flags. Spotted by
+	  Bart Lateur.
 
 0.15 2005-04-27 06:50:31 UTC
-    - Oops. Detabbed all the files and did not rerun the tests.
-      t/03_str.t explicitly performs a test on a literal TAB
-      character, and so it failed. Always, always, *ALWAYS* run
-      the test suite as the last task before uploading. Grrr.
+	- Oops. Detabbed all the files and did not rerun the tests.
+	  t/03_str.t explicitly performs a test on a literal TAB
+	  character, and so it failed. Always, always, *ALWAYS* run
+	  the test suite as the last task before uploading. Grrr.
 
 0.14 2005-04-27 00:32:43 UTC
-    - Performance tuning release. Played around significantly
-      with _insertr and lex but major improvement will only
-      come about by writing the lexing routine in C.
-    - Reordered $Default_Lexer to bring the most common cases
-      to the front of the pattern.
-    - Inline the effects of \U, \L, \c, \x. This is handled by
-      _lex_stateful (which offloads some of the worst case
-      lexing costs into a separate routine and thus makes the
-      more usual cases run faster). Handling of \Q in the
-      previous release was incorrect. (Sigh).
-    - Backslash slashes.
-    - Passed arrays around by reference between _lex and a
-      newly introduced _insertr routine.
-    - Silenced warning in _slide_tail (ran/reran)
-    - Fixed bug in _slide_tail (didn't handle '0' as a token).
-      One section of the code used to do its own sliding, now it
-      uses _slide_tail.
-    - Fixed bug in _node_eq revealed by 5.6.1 (implicit ordering
-      of hash keys).
-    - Optimized node_offset()
-    - replace ok() in tests by better things (is, like, ...)
-    - removed use of Test::Differences, since it doesn't work on
-      complex structures.
+	- Performance tuning release. Played around significantly
+	  with _insertr and lex but major improvement will only
+	  come about by writing the lexing routine in C.
+	- Reordered $Default_Lexer to bring the most common cases
+	  to the front of the pattern.
+	- Inline the effects of \U, \L, \c, \x. This is handled by
+	  _lex_stateful (which offloads some of the worst case
+	  lexing costs into a separate routine and thus makes the
+	  more usual cases run faster). Handling of \Q in the
+	  previous release was incorrect. (Sigh).
+	- Backslash slashes.
+	- Passed arrays around by reference between _lex and a
+	  newly introduced _insertr routine.
+	- Silenced warning in _slide_tail (ran/reran)
+	- Fixed bug in _slide_tail (didn't handle '0' as a token).
+	  One section of the code used to do its own sliding, now it
+	  uses _slide_tail.
+	- Fixed bug in _node_eq revealed by 5.6.1 (implicit ordering
+	  of hash keys).
+	- Optimized node_offset()
+	- replace ok() in tests by better things (is, like, ...)
+	- removed use of Test::Differences, since it doesn't work on
+	  complex structures.
 
 0.13 2005-04-11 21:59:26 UTC
-    - Deal with \Q...\E patterns.
-    - $Default_Lexer pattern fails on 5.6.x: it would lex
-      '\-' as '\', '-'.
-    - Tests to prove that the global $_ is not clobbered
-      by the module.
-    - Used cmp_ok rather than ok where it makes sense.
-    - Added a (belated) DEBUG_LEX debugging mode
+	- Deal with \Q...\E patterns.
+	- $Default_Lexer pattern fails on 5.6.x: it would lex
+	  '\-' as '\', '-'.
+	- Tests to prove that the global $_ is not clobbered
+	  by the module.
+	- Used cmp_ok rather than ok where it makes sense.
+	- Added a (belated) DEBUG_LEX debugging mode
 
 0.12 2005-04-11 23:49:16 UTC
-    - Forgot to guard against the possibility of
-      Test::Differences not being available. This would cause
-      erroneous failures in the test suite if it was not
-      installed.
-    - Quotemeta was still giving troubles. Exhaustive testing
-      also turned up the fact that a bare add('0') would be
-      ignored (and thus the null-match pattern would be returned.
-    - More tweaks to the documentation.
+	- Forgot to guard against the possibility of
+	  Test::Differences not being available. This would cause
+	  erroneous failures in the test suite if it was not
+	  installed.
+	- Quotemeta was still giving troubles. Exhaustive testing
+	  also turned up the fact that a bare add('0') would be
+	  ignored (and thus the null-match pattern would be returned.
+	- More tweaks to the documentation.
 
 0.11 Sat Apr 9 19:44:19 2005 UTC
-    - Performed coverage testing with Devel::Cover
-      Numerous tests added as a result. Borderline bugs
-      fixed (bizarre copy of ARRAY in leave under D::C -
-      fixed in 0.10).
-    - Finalised the interface to using zero-width lookahead
-      assertions. Depending on the match/failure ratio of
-      the pattern to targets, the pattern execution may be
-      slower with ZWLAs than without. Benchmark it.
-    - Made _dump call _dump_node if passed a reference to a
-      hash. This simplifies the code a bit, since one no
-      longer has to worry about whether the thing we are
-      looking at is a node or a path. All in all a minor
-      patch, just to tidy up some loose ends before
-      moving to heftier optimisations.
-    - The fix in 0.10 for quotemeta didn't go far enough.
-      Hopefully this version gets it right.
-    - A number of minor tweaks based on information
-      discovered during coverage testing.
-    - Added documentation about the mailing list. Sundry
-      documentation tweaks.
+	- Performed coverage testing with Devel::Cover
+	  Numerous tests added as a result. Borderline bugs
+	  fixed (bizarre copy of ARRAY in leave under D::C -
+	  fixed in 0.10).
+	- Finalised the interface to using zero-width lookahead
+	  assertions. Depending on the match/failure ratio of
+	  the pattern to targets, the pattern execution may be
+	  slower with ZWLAs than without. Benchmark it.
+	- Made _dump call _dump_node if passed a reference to a
+	  hash. This simplifies the code a bit, since one no
+	  longer has to worry about whether the thing we are
+	  looking at is a node or a path. All in all a minor
+	  patch, just to tidy up some loose ends before
+	  moving to heftier optimisations.
+	- The fix in 0.10 for quotemeta didn't go far enough.
+	  Hopefully this version gets it right.
+	- A number of minor tweaks based on information
+	  discovered during coverage testing.
+	- Added documentation about the mailing list. Sundry
+	  documentation tweaks.
 
 0.10 2005-03-29 09:01:49 UTC
-    - Correct Default_Lexer$ pattern to deal with the
-      excessively backslashed tokens that C<quotemeta>
-      likes to produce. Bug spotted by Walter Roberson.
-    - Added a fix to an obscure bug that Devel::Cover
-      uncovered. The next release will fold in similar
-      improvements found by using Devel::Cover.
+	- Correct Default_Lexer$ pattern to deal with the
+	  excessively backslashed tokens that C<quotemeta>
+	  likes to produce. Bug spotted by Walter Roberson.
+	- Added a fix to an obscure bug that Devel::Cover
+	  uncovered. The next release will fold in similar
+	  improvements found by using Devel::Cover.
 
 0.09 2005-01-22 9:28:21 UTC
-    - Added lookahead assertions at nodes. (This concept is
-      shamelessly pinched from Dan Kogai's Regexp::Optimizer).
-      The code is currently commented out, because in all my
-      benchmarks the resulting regexps are slower with them.
-      Look for calls to _combine if you want to play around
-      with this.
-    - $Default_Lexer and $Single_Char regexps updated to fix
-      a bug where backslashed characters were broken apart
-      between the backslash and the character, resulting in
-      uncompilable regexps.
-    - Character classes are now sorted to the left of a list of
-      alternations.
-    - Corrected license info in META.yml
-    - Started to switch from ok() to cmp_ok() in the test suite
-      to produce human-readable test failures.
+	- Added lookahead assertions at nodes. (This concept is
+	  shamelessly pinched from Dan Kogai's Regexp::Optimizer).
+	  The code is currently commented out, because in all my
+	  benchmarks the resulting regexps are slower with them.
+	  Look for calls to _combine if you want to play around
+	  with this.
+	- $Default_Lexer and $Single_Char regexps updated to fix
+	  a bug where backslashed characters were broken apart
+	  between the backslash and the character, resulting in
+	  uncompilable regexps.
+	- Character classes are now sorted to the left of a list of
+	  alternations.
+	- Corrected license info in META.yml
+	- Started to switch from ok() to cmp_ok() in the test suite
+	  to produce human-readable test failures.
 
 0.08 2005-01-03 11:23:50 UTC
-    - Bug in insert_node fixed: did not deal with the following
-      correctly: qw/bcktx bckx bdix bdktx bdkx/ (The assymetry
-      introduced by 'bdix' threw things off, or something like
-      that).
-    - Bug in reduced regexp generation (reinstated code that had
-      been excised from _re_path() et al).
-    - Rewrote the tests to eliminate the need for Test::Deep.
-      Test::More::is_deeply is sufficient.
+	- Bug in insert_node fixed: did not deal with the following
+	  correctly: qw/bcktx bckx bdix bdktx bdkx/ (The assymetry
+	  introduced by 'bdix' threw things off, or something like
+	  that).
+	- Bug in reduced regexp generation (reinstated code that had
+	  been excised from _re_path() et al).
+	- Rewrote the tests to eliminate the need for Test::Deep.
+	  Test::More::is_deeply is sufficient.
 
 0.07 2004-12-17 19:31:18 UTC
-    - It would have been nice to have remembered to update the
-      release date in the POD, and the version in the README.
+	- It would have been nice to have remembered to update the
+	  release date in the POD, and the version in the README.
 
 0.06 2004-12-17 17:38:41 UTC
-    - Can now track regular expressions. Given a match, it is
-      possible to determine which original pattern gave rise to the
-      match.
-    - Improved character class generation: . (anychar) was not
-      special-cased, which would have lead to a.b axb giving a[.x]b
-      Also takes into account single-char width metachars like \t
-      \e et al. Filters out digits if \d appears, and for similar
-      metachars (\D, \s, \W...)
-    - Added a pre_filter method, to perform input filtering prior
-      to the pattern being lexed.
-    - Added a flags method, to allow for (?imsx) pattern modifiers.
-    - enhanced the assemble script: added -b, -c, -d, -v;
-      documented -r
-    - Additions to the README
-    - Added Test::Simple and Test::More as prerequisites.
+	- Can now track regular expressions. Given a match, it is
+	  possible to determine which original pattern gave rise to the
+	  match.
+	- Improved character class generation: . (anychar) was not
+	  special-cased, which would have lead to a.b axb giving a[.x]b
+	  Also takes into account single-char width metachars like \t
+	  \e et al. Filters out digits if \d appears, and for similar
+	  metachars (\D, \s, \W...)
+	- Added a pre_filter method, to perform input filtering prior
+	  to the pattern being lexed.
+	- Added a flags method, to allow for (?imsx) pattern modifiers.
+	- enhanced the assemble script: added -b, -c, -d, -v;
+	  documented -r
+	- Additions to the README
+	- Added Test::Simple and Test::More as prerequisites.
 
 0.05 2004-12-10 11:52:13 UTC
-    - Bug fix in tests. The skip test in version 0.04 did not deal
-      correctly with non-5.6.0 perls that do not have Test::Deep
-      installed.
+	- Bug fix in tests. The skip test in version 0.04 did not deal
+	  correctly with non-5.6.0 perls that do not have Test::Deep
+	  installed.
 
 0.04 2004-12-09 22:29:56 UTC
-    - In 5.6.0, the backlashes in a quoted word list, qw[ \\d ],
-      will have their backslashes doubled up. In this case, don't
-      run the tests. (Reading from a file or getting input from
-      some other source other than qw[] operators works just fine).
+	- In 5.6.0, the backlashes in a quoted word list, qw[ \\d ],
+	  will have their backslashes doubled up. In this case, don't
+	  run the tests. (Reading from a file or getting input from
+	  some other source other than qw[] operators works just fine).
 
 0.03 2004-12-08 21:55:27 UTC
-    - Bug fix: Leading 0s could be omitted from paths because of the
-      difference between while($p) versus while(defined($p)).
-    - An assembled pattern can be generated with whitespace. This can be
-      used in conjunction with the /x modifier, and also for debugging.
-    - Code profiled: dead code paths removed, hotspots rewritten to run
-      more quickly.
-    - Documentation typos and wordos.
-    - assemble script now accepts a number of command line switches to
-      control its behaviour.
-    - More tests. Now with Test::Pod.
+	- Bug fix: Leading 0s could be omitted from paths because of the
+	  difference between while($p) versus while(defined($p)).
+	- An assembled pattern can be generated with whitespace. This can be
+	  used in conjunction with the /x modifier, and also for debugging.
+	- Code profiled: dead code paths removed, hotspots rewritten to run
+	  more quickly.
+	- Documentation typos and wordos.
+	- assemble script now accepts a number of command line switches to
+	  control its behaviour.
+	- More tests. Now with Test::Pod.
 
 0.02 2004-11-19 11:16:33 UTC
-    - An R::A object that has had nothing added to it now produces a
-      pattern that explicitly matches nothing (the original behaviour would
-      match anything).
-    - An object can now chomp its own input. Useful for slurping files. It
-      can also filter the input tokens and discard patterns that don't adhere
-      to what's expected (sanity checking e.g.: don't want spaces).
-    - Documented and added functions to allow for the lexer pattern to be
-      manipulated.
-    - The reset() method was commented out (and the test suite didn't catch
-      the fact).
-    - Detabbed the Assemble.pm, eg/* and t/* files (I like interpreting
-      tabs as four spaces, but this produces horrible indentation on
-      www.cpan.org).
-    - t/00_basic.t test counts were wrong. This showed up if Test::Deep was
-      not installed.
-    - t/02_reduce.t does not need to 'use Data::Dumper'.
-    - Tweaked eg/hostmatch/hostmatch; added eg/assemble, eg/assemble-check
-    - Typos, corrections and addtions to the documentation.
+	- An R::A object that has had nothing added to it now produces a
+	  pattern that explicitly matches nothing (the original behaviour would
+	  match anything).
+	- An object can now chomp its own input. Useful for slurping files. It
+	  can also filter the input tokens and discard patterns that don't adhere
+	  to what's expected (sanity checking e.g.: don't want spaces).
+	- Documented and added functions to allow for the lexer pattern to be
+	  manipulated.
+	- The reset() method was commented out (and the test suite didn't catch
+	  the fact).
+	- Detabbed the Assemble.pm, eg/* and t/* files (I like interpreting
+	  tabs as four spaces, but this produces horrible indentation on
+	  www.cpan.org).
+	- t/00_basic.t test counts were wrong. This showed up if Test::Deep was
+	  not installed.
+	- t/02_reduce.t does not need to 'use Data::Dumper'.
+	- Tweaked eg/hostmatch/hostmatch; added eg/assemble, eg/assemble-check
+	- Typos, corrections and addtions to the documentation.
 
 0.01 2004-07-09 21:05:18 UTC
-    - original version; created by h2xs 1.19 (seriously!)
+	- original version; created by h2xs 1.19 (seriously!)

--- a/LICENSE
+++ b/LICENSE
@@ -285,22 +285,22 @@ fashion, plus the right to make reasonable modifications.
 Definitions:
 
 -    "Package" refers to the collection of files distributed by the Copyright
-     Holder, and derivatives of that collection of files created through textual
-     modification.
+	 Holder, and derivatives of that collection of files created through textual
+	 modification.
 -    "Standard Version" refers to such a Package if it has not been modified,
-     or has been modified in accordance with the wishes of the Copyright
-     Holder.
+	 or has been modified in accordance with the wishes of the Copyright
+	 Holder.
 -    "Copyright Holder" is whoever is named in the copyright or copyrights for
-     the package.
+	 the package.
 -    "You" is you, if you're thinking about copying or distributing this Package.
 -    "Reasonable copying fee" is whatever you can justify on the basis of
-     media cost, duplication charges, time of people involved, and so on. (You
-     will not be required to justify it to the Copyright Holder, but only to the
-     computing community at large as a market that must bear the fee.)
+	 media cost, duplication charges, time of people involved, and so on. (You
+	 will not be required to justify it to the Copyright Holder, but only to the
+	 computing community at large as a market that must bear the fee.)
 -    "Freely Available" means that no fee is charged for the item itself, though
-     there may be fees involved in handling the item. It also means that
-     recipients of the item may redistribute it under the same conditions they
-     received it.
+	 there may be fees involved in handling the item. It also means that
+	 recipients of the item may redistribute it under the same conditions they
+	 received it.
 
 1. You may make and give away verbatim copies of the source form of the
 Standard Version of this Package without restriction, provided that you duplicate
@@ -314,41 +314,41 @@ way shall still be considered the Standard Version.
 that you insert a prominent notice in each changed file stating how and when
 you changed that file, and provided that you do at least ONE of the following:
 
-     a) place your modifications in the Public Domain or otherwise
-     make them Freely Available, such as by posting said modifications
-     to Usenet or an equivalent medium, or placing the modifications on
-     a major archive site such as ftp.uu.net, or by allowing the
-     Copyright Holder to include your modifications in the Standard
-     Version of the Package.
+	 a) place your modifications in the Public Domain or otherwise
+	 make them Freely Available, such as by posting said modifications
+	 to Usenet or an equivalent medium, or placing the modifications on
+	 a major archive site such as ftp.uu.net, or by allowing the
+	 Copyright Holder to include your modifications in the Standard
+	 Version of the Package.
 
-     b) use the modified Package only within your corporation or
-     organization.
+	 b) use the modified Package only within your corporation or
+	 organization.
 
-     c) rename any non-standard executables so the names do not
-     conflict with standard executables, which must also be provided,
-     and provide a separate manual page for each non-standard
-     executable that clearly documents how it differs from the Standard
-     Version.
+	 c) rename any non-standard executables so the names do not
+	 conflict with standard executables, which must also be provided,
+	 and provide a separate manual page for each non-standard
+	 executable that clearly documents how it differs from the Standard
+	 Version.
 
-     d) make other distribution arrangements with the Copyright Holder.
+	 d) make other distribution arrangements with the Copyright Holder.
 
 4. You may distribute the programs of this Package in object code or executable
 form, provided that you do at least ONE of the following:
 
-     a) distribute a Standard Version of the executables and library
-     files, together with instructions (in the manual page or equivalent)
-     on where to get the Standard Version.
+	 a) distribute a Standard Version of the executables and library
+	 files, together with instructions (in the manual page or equivalent)
+	 on where to get the Standard Version.
 
-     b) accompany the distribution with the machine-readable source of
-     the Package with your modifications.
+	 b) accompany the distribution with the machine-readable source of
+	 the Package with your modifications.
 
-     c) accompany any non-standard executables with their
-     corresponding Standard Version executables, giving the
-     non-standard executables non-standard names, and clearly
-     documenting the differences in manual pages (or equivalent),
-     together with instructions on where to get the Standard Version.
+	 c) accompany any non-standard executables with their
+	 corresponding Standard Version executables, giving the
+	 non-standard executables non-standard names, and clearly
+	 documenting the differences in manual pages (or equivalent),
+	 together with instructions on where to get the Standard Version.
 
-     d) make other distribution arrangements with the Copyright Holder.
+	 d) make other distribution arrangements with the Copyright Holder.
 
 5. You may charge a reasonable copying fee for any distribution of this Package.
 You may charge any fee you choose for support of this Package. You may not
@@ -374,5 +374,3 @@ WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
 PURPOSE.
 
 The End
-
-

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -30,6 +30,8 @@
 \.old$
 \.rej$
 \.tmp$
+\.swp$
+^~
 
 # Avoid OS-specific files/dirs
 #   Mac OSX metadata

--- a/README
+++ b/README
@@ -45,10 +45,10 @@ print $ra->re; # prints (?:a(?:b+(?:\d*\s+)?c|(?:\w+)?\d+))
 or
 
 my $ra = Regexp::Assemble->new
-    ->add( 'foo', 'bar', 'baz', 'foom' );
+	->add( 'foo', 'bar', 'baz', 'foom' );
 
 print "$_ matches\n" if /$ra/
-    for (qw/word more stuff food rabble bark/);
+	for (qw/word more stuff food rabble bark/);
 
 or
 
@@ -56,10 +56,10 @@ use Regexp::Assemble;
 my @word = qw/flip flop slip slop/;
 
 print Regexp::Assemble->new->add(@word)->as_string;
-    # produces [fs]l[io]p
+	# produces [fs]l[io]p
 
 print Regexp::Assemble->new->add(@word)->reduce(0)->as_string;
-    # produces (?:fl(?:ip|op)|sl(?:ip|op))
+	# produces (?:fl(?:ip|op)|sl(?:ip|op))
 
 See the ./eg directory for some example scripts.
 
@@ -73,29 +73,29 @@ the following script:
 use Regexp::Assemble;
 
 my $set = [
-    {
-        accept => [qw[ .cnn.net .cnn.com ]],
-        refuse => [qw[ ^media video ]],
-    },
-    {
-        accept => [qw[ .yahoo.com ]],
-    },
+	{
+		accept => [qw[ .cnn.net .cnn.com ]],
+		refuse => [qw[ ^media video ]],
+	},
+	{
+		accept => [qw[ .yahoo.com ]],
+	},
 ];
 
 my $ra = Regexp::Assemble->new;
 
 for my $s( @$set ) {
-    my $refuse = do {
-        if( not exists $s->{refuse} ) {
-            '';
-        }
-        else {
-            '(?<!'
-            . Regexp::Assemble->new->add( @{$s->{refuse}} )->as_string
-            . ')'
-        }
-    };
-    $ra->add( map { s/\./\\./g; "$refuse$_\$" } @{$s->{accept}} );
+	my $refuse = do {
+		if( not exists $s->{refuse} ) {
+			'';
+		}
+		else {
+			'(?<!'
+			. Regexp::Assemble->new->add( @{$s->{refuse}} )->as_string
+			. ')'
+		}
+	};
+	$ra->add( map { s/\./\\./g; "$refuse$_\$" } @{$s->{accept}} );
 }
 
 my $re = $ra->re;
@@ -103,9 +103,9 @@ my $re = $ra->re;
 print $ra->as_string, "\n";
 
 while( <> ) {
-    print;
-    chomp;
-    print "\t", (/$re/ ? 'yep' : 'nope'), "\n";
+	print;
+	chomp;
+	print "\t", (/$re/ ? 'yep' : 'nope'), "\n";
 }
 
 == example end ==
@@ -138,22 +138,22 @@ use strict;
 use Regexp::Assemble;
 
 my $dispatch = {
-    'a-(\\d+)'        => sub { my $v = shift; print "speed $v->[1]\n"; },
-    'a-(\\d+)-(\\d+)' => sub { my $v = shift; print "pressure $v->[1] over $v->[2]\n"; },
-    'a-(\\w+)-(\\w+)' => sub { my $v = shift; print "message $v->[1] from $v->[2]\n"; },
+	'a-(\\d+)'        => sub { my $v = shift; print "speed $v->[1]\n"; },
+	'a-(\\d+)-(\\d+)' => sub { my $v = shift; print "pressure $v->[1] over $v->[2]\n"; },
+	'a-(\\w+)-(\\w+)' => sub { my $v = shift; print "message $v->[1] from $v->[2]\n"; },
 };
 
 my $re = Regexp::Assemble->new( track => 1 )->add( keys %$dispatch );
 
 while( <> ) {
-    chomp;
-    if( $re->match($_) ) {
-        $dispatch->{ $re->matched }( $re->mvar() );
-    }
-    else {
-        last if /q/;
-        print "\tignored\n";
-    }
+	chomp;
+	if( $re->match($_) ) {
+		$dispatch->{ $re->matched }( $re->mvar() );
+	}
+	else {
+		last if /q/;
+		print "\tignored\n";
+	}
 }
 
 == example end ==
@@ -170,7 +170,7 @@ copying the parameter).
 I initially hoped that $^R would handle this sort of stuff for me, but
 there's a bug. Consider the following pattern:
 
-    a(?{1}) (?: b(?{2}) )?
+	a(?{1}) (?: b(?{2}) )?
 
 (whitespace added for clarity). This pattern will match both the strings
 'a' and 'ab', however, in both cases, $^R will be set to 1 aftewards. I
@@ -203,16 +203,16 @@ divergence in the first path is replace by a node (a hash) and the two
 different paths carry on from there:
 
   [c o n
-        |s => [s t r u c t i v e]
-        \t => [t a i n m e n t]
+		|s => [s t r u c t i v e]
+		\t => [t a i n m e n t]
   ]
 
 And then 'confinement':
 
   [c o n
-        |s => [s t r u c t i v e]
-        |t => [t a i n m e n t]
-        \f => [f i n e m e n t]
+		|s => [s t r u c t i v e]
+		|t => [t a i n m e n t]
+		\f => [f i n e m e n t]
   ]
 
 What happens if we add a path that runs out in the middle of a
@@ -222,27 +222,27 @@ the path can both continue on, and can also stop here:
 Add 'construct':
 
   [c o n
-        |s => [s t r u c t
-        |                 | '' => undef
-        |                 \ i => [i v e]
-        |     ]
-        |t => [t a i n m e n t]
-        \f => [f i n e m e n t]
+		|s => [s t r u c t
+		|                 | '' => undef
+		|                 \ i => [i v e]
+		|     ]
+		|t => [t a i n m e n t]
+		\f => [f i n e m e n t]
   ]
 
 It should be obvious to see how the contruct branch will produce the
 pattern /construct(?:ive)?/ . Or for a longer path 'constructively':
 
   [c o n
-        |s => [s t r u c t
-        |                 | '' => undef
-        |                 \ i => [i v e
-        |                              | '' => undef
-        |                              \ l => [l y]
-        |                        ]
-        |     ]
-        |t => [t a i n m e n t]
-        \f => [f i n e m e n t]
+		|s => [s t r u c t
+		|                 | '' => undef
+		|                 \ i => [i v e
+		|                              | '' => undef
+		|                              \ l => [l y]
+		|                        ]
+		|     ]
+		|t => [t a i n m e n t]
+		\f => [f i n e m e n t]
   ]
 
 This is the state of the internal structure before reduction. When
@@ -262,8 +262,8 @@ own R::A object and see what comes out:
 Gives:
 
   [t n e m
-          | n => [n i a t]
-          \ e => [e n i f]
+		  | n => [n i a t]
+		  \ e => [e n i f]
   ]
 
 When the algorithm visits the other path (s => [s t r u c t ...]),
@@ -284,20 +284,20 @@ root).
 Unreversing the t, f reduction gives:
 
   [ t => [t a i n] \
-    f => [f i n e] | m e n t ]
+	f => [f i n e] | m e n t ]
 
 When all is said and done, the final result gives
 
   [c o n
-        |s => [s t r u c t
-        |                 | '' => undef
-        |                 \ i => [i v e
-        |                              | '' => undef
-        |                              \ l => [l y]
-        |                        ]
-        |     ]
-        [ t => [t a i n]
-          f => [f i n e] m e n t ]
+		|s => [s t r u c t
+		|                 | '' => undef
+		|                 \ i => [i v e
+		|                              | '' => undef
+		|                              \ l => [l y]
+		|                        ]
+		|     ]
+		[ t => [t a i n]
+		  f => [f i n e] m e n t ]
   ]
 
 When this data structure is traversed to build the pattern, it gives
@@ -312,11 +312,11 @@ the reduction would have gone succeeded. We would have a common
 head [t], shared by all three paths.
 
   [t
-    | c => [c u r t s]
-    \ n => [n e m
-                 | n => [n i a t]
-                 \ e => [e n i f]
-           ]
+	| c => [c u r t s]
+	\ n => [n e m
+				 | n => [n i a t]
+				 \ e => [e n i f]
+		   ]
   ]
 
 And then consider that the path [c o u r t] had also been added to
@@ -324,26 +324,26 @@ the object. We would then be able to reduce the t from the above
 reduction, and the t in [c o u r t]
 
   [c o
-      | n => [n
-      |        | s => [s t r u c t]
-      |        | t => [t a i n m e n t]
-      |        \ f => [f i n e m e n t]
-      |      ]
-      \ u => [u r t]
+	  | n => [n
+	  |        | s => [s t r u c t]
+	  |        | t => [t a i n m e n t]
+	  |        \ f => [f i n e m e n t]
+	  |      ]
+	  \ u => [u r t]
   ]
 
 gives
 
   [c o
-      | n => [n
-      |        | s => [s t r u c]
-      |        \ f => [
-      |                 f => [f i n e]
-      |                 t => [t a i n]
-      |                 m e n
-      |               ]
-      |      ]
-      \ u => [u r]
+	  | n => [n
+	  |        | s => [s t r u c]
+	  |        \ f => [
+	  |                 f => [f i n e]
+	  |                 t => [t a i n]
+	  |                 m e n
+	  |               ]
+	  |      ]
+	  \ u => [u r]
    t
   ]
 
@@ -459,11 +459,13 @@ This module is under active development. The module is managed in
 a Subversion repository, and thus, the latest working copy is
 available at
 
-  http://svnweb.mongueurs.net/Regexp-Assemble/trunk
+  https://github.com/ronsavage/Regexp-Assemble
 
 AUTHOR
 
 David Landgren
+
+Ron Savage is co-maint of the module, starting with V 0.36.
 
 I do appreciate getting e-mail, especially about Perl. Please keep in
 mind that I get a lot of spam, and take drastic measures to reduce the

--- a/examples/assemble
+++ b/examples/assemble
@@ -20,32 +20,32 @@ print "$VERSION\n" and exit if $opt{v};
 $opt{d} |= 8 if $opt{T};
 
 my $ra = Regexp::Assemble->new(
-    chomp            => 1,
-    debug            => $opt{d} || 0,
-    fold_meta_pairs  => exists $opt{f} ? 0 : 1,
-    reduce           => exists $opt{r} ? 0 : 1,
-    dup_warn         => exists $opt{u} ? 1 : 0,
-    lookahead        => exists $opt{a} ? 1 : 0,
-    unroll_plus      => exists $opt{U} ? 1 : 0,
+	chomp            => 1,
+	debug            => $opt{d} || 0,
+	fold_meta_pairs  => exists $opt{f} ? 0 : 1,
+	reduce           => exists $opt{r} ? 0 : 1,
+	dup_warn         => exists $opt{u} ? 1 : 0,
+	lookahead        => exists $opt{a} ? 1 : 0,
+	unroll_plus      => exists $opt{U} ? 1 : 0,
 );
 
 if( $opt{b} or $opt{c} ) {
-    if( !$opt{b} ) {
-        # filter comments
-        $ra->pre_filter( sub { $_[0] =~ s/\s*#.*$//; 1 } );
-    }
-    elsif( !$opt{c} ) {
-        # filter blank lines
-        $ra->pre_filter( sub { length(shift) } );
-    }
-    else {
-        # filter comments and blank lines.
-        # (removing a comment may can cause a line to become blank
-        $ra->pre_filter( sub {
-            $_[0] =~ s/\s*#.*$//;
-            length($_[0])
-        } );
-    }
+	if( !$opt{b} ) {
+		# filter comments
+		$ra->pre_filter( sub { $_[0] =~ s/\s*#.*$//; 1 } );
+	}
+	elsif( !$opt{c} ) {
+		# filter blank lines
+		$ra->pre_filter( sub { length(shift) } );
+	}
+	else {
+		# filter comments and blank lines.
+		# (removing a comment may can cause a line to become blank
+		$ra->pre_filter( sub {
+			$_[0] =~ s/\s*#.*$//;
+			length($_[0])
+		} );
+	}
 }
 
 $ra->add( <> );
@@ -54,32 +54,32 @@ $ra->add( <> );
 $ra->_reduce() if $opt{S} and $opt{d} and ($opt{d} & 8);
 
 if( $opt{i} or $opt{p} or not ($opt{t} or $opt{S}) ) {
-    print $ra->as_string( indent => $opt{i} || 0 );
-    print "\n" unless $opt{n};
+	print $ra->as_string( indent => $opt{i} || 0 );
+	print "\n" unless $opt{n};
 }
 
 if( $opt{s} or $opt{S} ) {
-    warn qq{# nr=@{[$ra->stats_add]} dup=@{[$ra->stats_dup]} raw=@{[$ra->stats_raw]} cooked=@{[$ra->stats_cooked]} len=@{[$ra->stats_length]}\n};
+	warn qq{# nr=@{[$ra->stats_add]} dup=@{[$ra->stats_dup]} raw=@{[$ra->stats_raw]} cooked=@{[$ra->stats_cooked]} len=@{[$ra->stats_length]}\n};
 }
 
 if( $opt{t} ) {
-    my $error = 0;
-    my $file = $opt{t};
-    open IN, $file or die "Cannot open $file for input: $!\n";
-    print $ra->as_string, "\n";
-    while( <IN> ) {
-        chomp;
-        if( $opt{w} ) {
-            next if $_ =~ /^$ra$/;
-        }
-        else {
-            next if $_ =~ /$ra/;
-        }
-        print "FAIL <$_>\n";
-        ++$error;
-    }
-    close IN;
-    exit $error ? 1 : 0;
+	my $error = 0;
+	my $file = $opt{t};
+	open IN, $file or die "Cannot open $file for input: $!\n";
+	print $ra->as_string, "\n";
+	while( <IN> ) {
+		chomp;
+		if( $opt{w} ) {
+			next if $_ =~ /^$ra$/;
+		}
+		else {
+			next if $_ =~ /$ra/;
+		}
+		print "FAIL <$_>\n";
+		++$error;
+	}
+	close IN;
+	exit $error ? 1 : 0;
 }
 
 =head1 NAME
@@ -205,4 +205,3 @@ Copyright (C) 2004-2008 David Landgren. All rights reserved.
 
 This script is free software; you can redistribute it and/or modify it
 under the same terms as Perl itself.
-

--- a/examples/debugging
+++ b/examples/debugging
@@ -20,32 +20,32 @@ print "$VERSION\n" and exit if $opt{v};
 my $r = Regexp::Assemble->new;
 
 while( <> ) {
-    chomp;
+	chomp;
 
-    # take a copy of the assembly and add the next pattern
-    my $clone = $r->clone;
-    $clone->add($_);
+	# take a copy of the assembly and add the next pattern
+	my $clone = $r->clone;
+	$clone->add($_);
 
-    # if we compile the regexp, does it blow up?
-    eval { my $regexp = $clone->re };
+	# if we compile the regexp, does it blow up?
+	eval { my $regexp = $clone->re };
 
-    # it blew up
-    if( $@ ) {
-        report();
-    }
-    else {
-        # ok, now add it for real to the assembly
-        $r->add( $_ );
-    }
+	# it blew up
+	if( $@ ) {
+		report();
+	}
+	else {
+		# ok, now add it for real to the assembly
+		$r->add( $_ );
+	}
 }
 
 sub report {
-    my $lsqb = $_ =~ tr/[/[/;
-    my $rsqb = $_ =~ tr/]/]/;
-    my $lpar = $_ =~ tr/(/(/;
-    my $rpar = $_ =~ tr/)/)/;
+	my $lsqb = $_ =~ tr/[/[/;
+	my $rsqb = $_ =~ tr/]/]/;
+	my $lpar = $_ =~ tr/(/(/;
+	my $rpar = $_ =~ tr/)/)/;
 
-    warn <<WARNING;
+	warn <<WARNING;
 $ARGV($.): [$_]
 counts: [=$lsqb ]=$rsqb (=$lpar )=$rpar
 The above line causes the assembly to fail. Look for unbalanced parens or

--- a/examples/failure.01.pl
+++ b/examples/failure.01.pl
@@ -6,50 +6,50 @@ use Data::Dumper;
 
 my $re = Regexp::Assemble->new(flags => 'i')->track(1);
 
-foreach my $reg ( 
+foreach my $reg (
   '(?^ux: Coneheads(?^ux: [^\\p{Alnum}] )(?^ux: [^\\p{Alnum}] )(?^ux: [^\\p{Alnum}] )Dan(?^ux: [^\\p{Alnum}] )Aykroyd(?^ux: [^\\p{Alnum}] )Comedy(?^ux: [^\\p{Alnum}] )Eng )|(?^ux: Coneheads(?:[+]|%20)-(?:[+]|%20)Dan(?:[+]|%20)Aykroyd(?:[+]|%20)Comedy(?:[+]|%20)Eng)',
 #  'Coneheads(?^ux: [^\\p{Alnum}] )(?^ux: [^\\p{Alnum}] )(?^ux: [^\\p{Alnum}] )Dan(?^ux: [^\\p{Alnum}] )Aykroyd(?^ux: [^\\p{Alnum}] )Comedy(?^ux: [^\\p{Alnum}] )Eng',
 #  'Coneheads(?:[+]|%20)-(?:[+]|%20)Dan(?:[+]|%20)Aykroyd(?:[+]|%20)Comedy(?:[+]|%20)Eng',
   '(?^u:Coneheads\\ 1993)',
 ) {
-    $re->add( $reg );
+	$re->add( $reg );
 }
 
-foreach my $string ( 
-    "Coneheads - Dan Aykroyd Comedy Eng",
-    "Coneheads+-+Dan+Aykroyd+Comedy+Eng",
-    "Coneheads%20-%20Dan%20Aykroyd%20Comedy%20Eng",
-    "Coneheads 1993",
+foreach my $string (
+	"Coneheads - Dan Aykroyd Comedy Eng",
+	"Coneheads+-+Dan+Aykroyd+Comedy+Eng",
+	"Coneheads%20-%20Dan%20Aykroyd%20Comedy%20Eng",
+	"Coneheads 1993",
 ) {
-    if( $string =~ /$re/ ) {
-        say "matched $string";
+	if( $string =~ /$re/ ) {
+		say "matched $string";
 
-        if( my $matched = $re->matched() ) {
-            say "matched with: $matched";
-        }
-        if( my $matched = $re->source($^R) ) {
-            say "\$^R: $^R";
-            say "match source: $matched";
-        }
+		if( my $matched = $re->matched() ) {
+			say "matched with: $matched";
+		}
+		if( my $matched = $re->source($^R) ) {
+			say "\$^R: $^R";
+			say "match source: $matched";
+		}
 
-        say "work around: ", get_source($re, $string);
-    }
-    else {
-        say "no match on $string";
-        say "get_source returns: ",  get_source($re, $string);
-    }
-    say "-" x 70;
+		say "work around: ", get_source($re, $string);
+	}
+	else {
+		say "no match on $string";
+		say "get_source returns: ",  get_source($re, $string);
+	}
+	say "-" x 70;
 }
 
 print Dumper $re;
 
 sub get_source {
-    my ($re, $string) = @_;
+	my ($re, $string) = @_;
 
-    foreach my $r ( @{$re->{mlist}} ) {
-        if( $string =~ /$r/ ) {
-            return $r;
-        }
-    }
-    return;
+	foreach my $r ( @{$re->{mlist}} ) {
+		if( $string =~ /$r/ ) {
+			return $r;
+		}
+	}
+	return;
 }

--- a/examples/fee
+++ b/examples/fee
@@ -6,10 +6,10 @@ use Regexp::Assemble;
 my $re = Regexp::Assemble->new->add( qw[ fee fie foe fum ] );
 
 while( <DATA> ) {
-    chomp;
-    if( /($re)/ ) {
-        print "Here be giants: $1\n";
-    }
+	chomp;
+	if( /($re)/ ) {
+		print "Here be giants: $1\n";
+	}
 }
 
 print $re->as_string, "\n";

--- a/examples/hostmatch/hostmatch
+++ b/examples/hostmatch/hostmatch
@@ -13,14 +13,14 @@ open BAD,   '>bad.out'   or die "Cannot open bad.out for output: $!\n";
 
 my( $good, $bad ) = (0, 0);
 while( <> ) {
-    chomp;
-    if( /^$ra$/ ) {
-        ++$bad;
-    }
-    else {
-        print GOOD "$_\n";
-        ++$good;
-    }
+	chomp;
+	if( /^$ra$/ ) {
+		++$bad;
+	}
+	else {
+		print GOOD "$_\n";
+		++$good;
+	}
 }
 
 close GOOD;

--- a/examples/ircwatcher
+++ b/examples/ircwatcher
@@ -18,33 +18,33 @@ use strict;
 use Regexp::Assemble;
 
 my %dispatch = (
-    '^\*\*\* (\S+) joined channel (\S+)$'           => \&joined,
-    '^\*\*\* (\S+) left channel (\S+) reason (.*)$' => \&left,
-    '^q$' => sub { exit },
+	'^\*\*\* (\S+) joined channel (\S+)$'           => \&joined,
+	'^\*\*\* (\S+) left channel (\S+) reason (.*)$' => \&left,
+	'^q$' => sub { exit },
 );
 
 my $re = Regexp::Assemble->new
-    ->track(1)
-    ->add(keys %dispatch);
+	->track(1)
+	->add(keys %dispatch);
 
 sub joined {
-    my ($who, $channel) = @_;
-    print "$who joined $channel\n";
+	my ($who, $channel) = @_;
+	print "$who joined $channel\n";
 }
 
 sub left {
-    my ($who, $channel, $reason) = @_;
-    print "$who left $channel saying $reason\n";
+	my ($who, $channel, $reason) = @_;
+	print "$who left $channel saying $reason\n";
 }
 
 while( <STDIN> ) {
-    chomp;
-    if ($re->match($_)) {
-        $dispatch{$re->matched}->($re->capture);
-    }
-    else {
-        print "ignored <$_>\n";
-    }
+	chomp;
+	if ($re->match($_)) {
+		$dispatch{$re->matched}->($re->capture);
+	}
+	else {
+		print "ignored <$_>\n";
+	}
 }
 
 __DATA__

--- a/examples/stress-test.pl
+++ b/examples/stress-test.pl
@@ -9,7 +9,7 @@ use Algorithm::Combinatorics 'combinations';
 my $end = shift || 'e'; # generate the power set of the elements 'a' .. $end
 
 my $set = [sort {join('' => @$a) cmp join('' => @$b)}
-    @{Data::PowerSet::powerset( {min=>1}, 'a'..$end )}
+	@{Data::PowerSet::powerset( {min=>1}, 'a'..$end )}
 ];
 
 $| = 1;
@@ -18,76 +18,76 @@ print "## size of powerset = ", scalar(@$set), "\n";
 
 my $nr = 0;
 for my $sel (@ARGV) {
-    my $p = combinations($set,$sel);
+	my $p = combinations($set,$sel);
 
-    while (defined(my $s = $p->next)) {
-        ++$nr;
-        my $short = Regexp::Assemble->new;
-        $short->insert(@$_) for @$s;
-        my $long  = Regexp::Assemble->new;
-        $long->insert('^', @$_, '$') for @$s;
-        my $sh = $short->as_string;
-        my $lg = $long->as_string;
+	while (defined(my $s = $p->next)) {
+		++$nr;
+		my $short = Regexp::Assemble->new;
+		$short->insert(@$_) for @$s;
+		my $long  = Regexp::Assemble->new;
+		$long->insert('^', @$_, '$') for @$s;
+		my $sh = $short->as_string;
+		my $lg = $long->as_string;
 
-        $s = [map {join '' => @$_} @$s];
-        printf "%9d %2d %s $lg\n", $nr, $sel, "@$s" unless $nr % 10000;
+		$s = [map {join '' => @$_} @$s];
+		printf "%9d %2d %s $lg\n", $nr, $sel, "@$s" unless $nr % 10000;
 
-        my %expected = map{($_,$_)} @$s;
-        if( "^$sh\$" ne $lg ) {
-            $lg =~ s/^\^//;
-            $lg =~ s/\$$//;
+		my %expected = map{($_,$_)} @$s;
+		if( "^$sh\$" ne $lg ) {
+			$lg =~ s/^\^//;
+			$lg =~ s/\$$//;
 
-            for my $t ( @$s) {
-                if( $expected{$t} ) {
-                    next if $t =~ /$long/;
-                    printf "%5d %-50s %s\n", $nr, $lg, "@$s";
-                    print "l: $t should have been matched\n";
-                    last;
-                }
-                else {
-                    next if $t !~ /$long/;
-                    printf "%5d %-50s %s\n", $nr, $lg, "@$s";
-                    print "l: $t should not have been matched\n";
-                    last;
-                }
-            }
+			for my $t ( @$s) {
+				if( $expected{$t} ) {
+					next if $t =~ /$long/;
+					printf "%5d %-50s %s\n", $nr, $lg, "@$s";
+					print "l: $t should have been matched\n";
+					last;
+				}
+				else {
+					next if $t !~ /$long/;
+					printf "%5d %-50s %s\n", $nr, $lg, "@$s";
+					print "l: $t should not have been matched\n";
+					last;
+				}
+			}
 
-            my $short_str = '^' . $sh . '$';
-            my $short_re  = qr/$short_str/;
-            for my $t ( @$s) {
-                if( $expected{$t} ) {
-                    next if $t =~ /$short_re/;
-                    printf "%5d %-50s %s\n", $nr, $sh, "@$s";
-                    print "s: $t should have been matched\n";
-                    last;
-                }
-                else {
-                    next if $t !~ /$short_re/;
-                    printf "%5d %-50s %s\n", $nr, $sh, "@$s";
-                    print "s: $t should not have been matched\n";
-                    last;
-                }
-            }
+			my $short_str = '^' . $sh . '$';
+			my $short_re  = qr/$short_str/;
+			for my $t ( @$s) {
+				if( $expected{$t} ) {
+					next if $t =~ /$short_re/;
+					printf "%5d %-50s %s\n", $nr, $sh, "@$s";
+					print "s: $t should have been matched\n";
+					last;
+				}
+				else {
+					next if $t !~ /$short_re/;
+					printf "%5d %-50s %s\n", $nr, $sh, "@$s";
+					print "s: $t should not have been matched\n";
+					last;
+				}
+			}
 
-        }
-        else {
-            for my $t ( @$s) {
-                if( $expected{$t} ) {
-                    next if $t =~ /$long/;
-                    printf "%5d %-50s %s\n", $nr, $lg, "@$s";
-                    print "$t should have been matched\n";
-                    last;
-                }
-                else {
-                    next if $t !~ /$long/;
-                    printf "%5d %-50s %s\n", $nr, $sh, "@$s";
-                    print "$t should not have been matched\n";
-                    last;
-                }
-            }
-        }
-    }
-    print "# $sel $nr\n";
+		}
+		else {
+			for my $t ( @$s) {
+				if( $expected{$t} ) {
+					next if $t =~ /$long/;
+					printf "%5d %-50s %s\n", $nr, $lg, "@$s";
+					print "$t should have been matched\n";
+					last;
+				}
+				else {
+					next if $t !~ /$long/;
+					printf "%5d %-50s %s\n", $nr, $sh, "@$s";
+					print "$t should not have been matched\n";
+					last;
+				}
+			}
+		}
+	}
+	print "# $sel $nr\n";
 }
 
 print "$nr combinations examined\n";

--- a/examples/unquotemeta
+++ b/examples/unquotemeta
@@ -1,22 +1,22 @@
 #! /usr/bin/perl
 #
 # unquotemeta - how to fix up quotemeta
-# 
+#
 # part of the Regexp::Assemble module
 # David Landgren, copyright (c) 2005
 
 use strict;
 
 for my $ord( 0 .. 255 ) {
-    my $ch = chr($ord);
-    my $qm = quotemeta($ch);
-    my $fix = fixup($qm);
+	my $ch = chr($ord);
+	my $qm = quotemeta($ch);
+	my $fix = fixup($qm);
 
-    print "o=$ord c=$ch q=$qm f=$fix\n";
+	print "o=$ord c=$ch q=$qm f=$fix\n";
 }
 
 sub fixup {
-    my $ch = shift;
-    $ch =~ s/^\\([^-\w$()*+.\/?@\[\\\]^{|}])$/$1/;
-    $ch;
+	my $ch = shift;
+	$ch =~ s/^\\([^-\w$()*+.\/?@\[\\\]^{|}])$/$1/;
+	$ch;
 }

--- a/lib/Regexp/Assemble.pm
+++ b/lib/Regexp/Assemble.pm
@@ -30,804 +30,804 @@ our $VERSION = '0.38';
 # ------------------------------------------------
 
 sub new {
-    my $class = shift;
-    my %args  = @_;
+	my $class = shift;
+	my %args  = @_;
 
-    my $anc;
-    for $anc (qw(word line string)) {
-        if (exists $args{"anchor_$anc"}) {
-            my $val = delete $args{"anchor_$anc"};
-            for my $anchor ("anchor_${anc}_begin", "anchor_${anc}_end") {
-                $args{$anchor} = $val unless exists $args{$anchor};
-            }
-        }
-    }
+	my $anc;
+	for $anc (qw(word line string)) {
+		if (exists $args{"anchor_$anc"}) {
+			my $val = delete $args{"anchor_$anc"};
+			for my $anchor ("anchor_${anc}_begin", "anchor_${anc}_end") {
+				$args{$anchor} = $val unless exists $args{$anchor};
+			}
+		}
+	}
 
-    # anchor_string_absolute sets anchor_string_begin and anchor_string_end_absolute
-    if (exists $args{anchor_string_absolute}) {
-        my $val = delete $args{anchor_string_absolute};
-        for my $anchor (qw(anchor_string_begin anchor_string_end_absolute)) {
-            $args{$anchor} = $val unless exists $args{$anchor};
-        }
-    }
+	# anchor_string_absolute sets anchor_string_begin and anchor_string_end_absolute
+	if (exists $args{anchor_string_absolute}) {
+		my $val = delete $args{anchor_string_absolute};
+		for my $anchor (qw(anchor_string_begin anchor_string_end_absolute)) {
+			$args{$anchor} = $val unless exists $args{$anchor};
+		}
+	}
 
-    exists $args{$_} or $args{$_} = 0 for qw(
-        anchor_word_begin
-        anchor_word_end
-        anchor_line_begin
-        anchor_line_end
-        anchor_string_begin
-        anchor_string_end
-        anchor_string_end_absolute
-        debug
-        dup_warn
-        indent
-        lookahead
-        mutable
-        track
-        unroll_plus
-    );
+	exists $args{$_} or $args{$_} = 0 for qw(
+		anchor_word_begin
+		anchor_word_end
+		anchor_line_begin
+		anchor_line_end
+		anchor_string_begin
+		anchor_string_end
+		anchor_string_end_absolute
+		debug
+		dup_warn
+		indent
+		lookahead
+		mutable
+		track
+		unroll_plus
+	);
 
-    exists $args{$_} or $args{$_} = 1 for qw(
-        fold_meta_pairs
-        reduce
-        chomp
-    );
+	exists $args{$_} or $args{$_} = 1 for qw(
+		fold_meta_pairs
+		reduce
+		chomp
+	);
 
-    @args{qw(re str path)} = (undef, undef, []);
+	@args{qw(re str path)} = (undef, undef, []);
 
-    $args{flags} ||= delete $args{modifiers} || '';
-    $args{lex}     = $Current_Lexer if defined $Current_Lexer;
+	$args{flags} ||= delete $args{modifiers} || '';
+	$args{lex}     = $Current_Lexer if defined $Current_Lexer;
 
-    my $self = bless \%args, $class;
+	my $self = bless \%args, $class;
 
-    if ($self->_debug(DEBUG_TIME)) {
-        $self->_init_time_func();
-        $self->{_begin_time} = $self->{_time_func}->();
-    }
-    $self->{input_record_separator} = delete $self->{rs}
-        if exists $self->{rs};
-    exists $self->{file} and $self->add_file($self->{file});
+	if ($self->_debug(DEBUG_TIME)) {
+		$self->_init_time_func();
+		$self->{_begin_time} = $self->{_time_func}->();
+	}
+	$self->{input_record_separator} = delete $self->{rs}
+		if exists $self->{rs};
+	exists $self->{file} and $self->add_file($self->{file});
 
-    return $self;
+	return $self;
 }
 
 sub _init_time_func {
-    my $self = shift;
-    return if exists $self->{_time_func};
+	my $self = shift;
+	return if exists $self->{_time_func};
 
-    # attempt to improve accuracy
-    if (!defined($self->{_use_time_hires})) {
-        eval {require Time::HiRes};
-        $self->{_use_time_hires} = $@;
-    }
-    $self->{_time_func} = length($self->{_use_time_hires}) > 0
-        ? sub { time }
-        : \&Time::HiRes::time
-    ;
+	# attempt to improve accuracy
+	if (!defined($self->{_use_time_hires})) {
+		eval {require Time::HiRes};
+		$self->{_use_time_hires} = $@;
+	}
+	$self->{_time_func} = length($self->{_use_time_hires}) > 0
+		? sub { time }
+		: \&Time::HiRes::time
+	;
 }
 
 sub clone {
-    my $self = shift;
-    my $clone;
-    my @attr = grep {$_ ne 'path'} keys %$self;
-    @{$clone}{@attr} = @{$self}{@attr};
-    $clone->{path}   = _path_clone($self->_path);
-    bless $clone, ref($self);
+	my $self = shift;
+	my $clone;
+	my @attr = grep {$_ ne 'path'} keys %$self;
+	@{$clone}{@attr} = @{$self}{@attr};
+	$clone->{path}   = _path_clone($self->_path);
+	bless $clone, ref($self);
 }
 
 sub _fastlex {
-    my $self   = shift;
-    my $record = shift;
-    my $len    = 0;
-    my @path   = ();
-    my $case   = '';
-    my $qm     = '';
+	my $self   = shift;
+	my $record = shift;
+	my $len    = 0;
+	my @path   = ();
+	my $case   = '';
+	my $qm     = '';
 
-    my $debug       = $self->{debug} & DEBUG_LEX;
-    my $unroll_plus = $self->{unroll_plus};
+	my $debug       = $self->{debug} & DEBUG_LEX;
+	my $unroll_plus = $self->{unroll_plus};
 
-    my $token;
-    my $qualifier;
-    $debug and print "# _lex <$record>\n";
-    my $modifier        = q{(?:[*+?]\\??|\\{(?:\\d+(?:,\d*)?|,\d+)\\}\\??)?};
-    my $class_matcher   = qr/\[(?:\[:[a-z]+:\]|\\?.)*?\]/;
-    my $paren_matcher   = qr/\(.*?(?<!\\)\)$modifier/;
-    my $misc_matcher    = qr/(?:(c)(.)|(0)(\d{2}))($modifier)/;
-    my $regular_matcher = qr/([^\\[(])($modifier)/;
-    my $qm_matcher      = qr/(\\?.)/;
+	my $token;
+	my $qualifier;
+	$debug and print "# _lex <$record>\n";
+	my $modifier        = q{(?:[*+?]\\??|\\{(?:\\d+(?:,\d*)?|,\d+)\\}\\??)?};
+	my $class_matcher   = qr/\[(?:\[:[a-z]+:\]|\\?.)*?\]/;
+	my $paren_matcher   = qr/\(.*?(?<!\\)\)$modifier/;
+	my $misc_matcher    = qr/(?:(c)(.)|(0)(\d{2}))($modifier)/;
+	my $regular_matcher = qr/([^\\[(])($modifier)/;
+	my $qm_matcher      = qr/(\\?.)/;
 
-    my $matcher = $regular_matcher;
-    {
-        if ($record =~ /\G$matcher/gc) {
-            # neither a \\ nor [ nor ( followed by a modifer
-            if ($1 eq '\\E') {
-                $debug and print "#   E\n";
-                $case = $qm = '';
-                $matcher = $regular_matcher;
-                redo;
-            }
-            elsif ($qm and ($1 eq '\\L' or $1 eq '\\U')) {
-                $debug and print "#  ignore \\L, \\U\n";
-                redo;
-            }
-            $token = $1;
-            $qualifier = defined $2 ? $2 : '';
-            $debug and print "#  token <$token> <$qualifier>\n";
-            if ($qm) {
-                $token = quotemeta($token);
-                $token =~ s/^\\([^\w$()*+.?@\[\\\]^|{}\/])$/$1/;
-            }
-            else {
-                $token =~ s{\A([][{}*+?@\\/])\Z}{\\$1};
-            }
-            if ($unroll_plus and $qualifier =~ s/\A\+(\?)?\Z/*/) {
-                $1 and $qualifier .= $1;
-                $debug and print " unroll <$token><$token><$qualifier>\n";
-                $case and $token = $case eq 'L' ? lc($token) : uc($token);
-                push @path, $token, "$token$qualifier";
-            }
-            else {
-                $debug and print " clean <$token>\n";
-                push @path,
-                      $case eq 'L' ? lc($token).$qualifier
-                    : $case eq 'U' ? uc($token).$qualifier
-                    :                   $token.$qualifier
-                    ;
-            }
-            redo;
-        }
+	my $matcher = $regular_matcher;
+	{
+		if ($record =~ /\G$matcher/gc) {
+			# neither a \\ nor [ nor ( followed by a modifer
+			if ($1 eq '\\E') {
+				$debug and print "#   E\n";
+				$case = $qm = '';
+				$matcher = $regular_matcher;
+				redo;
+			}
+			elsif ($qm and ($1 eq '\\L' or $1 eq '\\U')) {
+				$debug and print "#  ignore \\L, \\U\n";
+				redo;
+			}
+			$token = $1;
+			$qualifier = defined $2 ? $2 : '';
+			$debug and print "#  token <$token> <$qualifier>\n";
+			if ($qm) {
+				$token = quotemeta($token);
+				$token =~ s/^\\([^\w$()*+.?@\[\\\]^|{}\/])$/$1/;
+			}
+			else {
+				$token =~ s{\A([][{}*+?@\\/])\Z}{\\$1};
+			}
+			if ($unroll_plus and $qualifier =~ s/\A\+(\?)?\Z/*/) {
+				$1 and $qualifier .= $1;
+				$debug and print " unroll <$token><$token><$qualifier>\n";
+				$case and $token = $case eq 'L' ? lc($token) : uc($token);
+				push @path, $token, "$token$qualifier";
+			}
+			else {
+				$debug and print " clean <$token>\n";
+				push @path,
+					  $case eq 'L' ? lc($token).$qualifier
+					: $case eq 'U' ? uc($token).$qualifier
+					:                   $token.$qualifier
+					;
+			}
+			redo;
+		}
 
-        elsif ($record =~ /\G\\/gc) {
-            $debug and print "#  backslash\n";
-            # backslash
-            if ($record =~ /\G([sdwSDW])($modifier)/gc) {
-                ($token, $qualifier) = ($1, $2);
-                $debug and print "#   meta <$token> <$qualifier>\n";
-                push @path, ($unroll_plus and $qualifier =~ s/\A\+(\?)?\Z/*/)
-                    ? ("\\$token", "\\$token$qualifier" . (defined $1 ? $1 : ''))
-                    : "\\$token$qualifier";
-            }
-            elsif ($record =~ /\Gx([\da-fA-F]{2})($modifier)/gc) {
-                $debug and print "#   x $1\n";
-                $token = quotemeta(chr(hex($1)));
-                $qualifier = $2;
-                $debug and print "#  cooked <$token>\n";
-                $token =~ s/^\\([^\w$()*+.?\[\\\]^|{\/])$/$1/; # } balance
-                $debug and print "#   giving <$token>\n";
-                push @path, ($unroll_plus and $qualifier =~ s/\A\+(\?)?\Z/*/)
-                    ? ($token, "$token$qualifier" . (defined $1 ? $1 : ''))
-                    : "$token$qualifier";
-            }
-            elsif ($record =~ /\GQ/gc) {
-                $debug and print "#   Q\n";
-                $qm = 1;
-                $matcher = $qm_matcher;
-            }
-            elsif ($record =~ /\G([LU])/gc) {
-                $debug and print "#   case $1\n";
-                $case = $1;
-            }
-            elsif ($record =~ /\GE/gc) {
-                $debug and print "#   E\n";
-                $case = $qm = '';
-                $matcher = $regular_matcher;
-            }
-            elsif ($record =~ /\G([lu])(.)/gc) {
-                $debug and print "#   case $1 to <$2>\n";
-                push @path, $1 eq 'l' ? lc($2) : uc($2);
-            }
-            elsif (my @arg = grep {defined} $record =~ /\G$misc_matcher/gc) {
-                if ($] < 5.007) {
-                    my $len = 0;
-                    $len += length($_) for @arg;
-                    $debug and print "#  pos ", pos($record), " fixup add $len\n";
-                    pos($record) = pos($record) + $len;
-                }
-                my $directive = shift @arg;
-                if ($directive eq 'c') {
-                    $debug and print "#  ctrl <@arg>\n";
-                    push @path, "\\c" . uc(shift @arg);
-                }
-                else { # elsif ($directive eq '0') {
-                    $debug and print "#  octal <@arg>\n";
-                    my $ascii = oct(shift @arg);
-                    push @path, ($ascii < 32)
-                        ? "\\c" . chr($ascii+64)
-                        : chr($ascii)
-                    ;
-                }
-                $path[-1] .= join( '', @arg ); # if @arg;
-                redo;
-            }
-            elsif ($record =~ /\G(.)/gc) {
-                $token = $1;
-                $token =~ s{[AZabefnrtz\[\]{}()\\\$*+.?@|/^]}{\\$token};
-                $debug and print "#   meta <$token>\n";
-                push @path, $token;
-            }
-            else {
-                $debug and print "#   ignore char at ", pos($record), " of <$record>\n";
-            }
-            redo;
-        }
+		elsif ($record =~ /\G\\/gc) {
+			$debug and print "#  backslash\n";
+			# backslash
+			if ($record =~ /\G([sdwSDW])($modifier)/gc) {
+				($token, $qualifier) = ($1, $2);
+				$debug and print "#   meta <$token> <$qualifier>\n";
+				push @path, ($unroll_plus and $qualifier =~ s/\A\+(\?)?\Z/*/)
+					? ("\\$token", "\\$token$qualifier" . (defined $1 ? $1 : ''))
+					: "\\$token$qualifier";
+			}
+			elsif ($record =~ /\Gx([\da-fA-F]{2})($modifier)/gc) {
+				$debug and print "#   x $1\n";
+				$token = quotemeta(chr(hex($1)));
+				$qualifier = $2;
+				$debug and print "#  cooked <$token>\n";
+				$token =~ s/^\\([^\w$()*+.?\[\\\]^|{\/])$/$1/; # } balance
+				$debug and print "#   giving <$token>\n";
+				push @path, ($unroll_plus and $qualifier =~ s/\A\+(\?)?\Z/*/)
+					? ($token, "$token$qualifier" . (defined $1 ? $1 : ''))
+					: "$token$qualifier";
+			}
+			elsif ($record =~ /\GQ/gc) {
+				$debug and print "#   Q\n";
+				$qm = 1;
+				$matcher = $qm_matcher;
+			}
+			elsif ($record =~ /\G([LU])/gc) {
+				$debug and print "#   case $1\n";
+				$case = $1;
+			}
+			elsif ($record =~ /\GE/gc) {
+				$debug and print "#   E\n";
+				$case = $qm = '';
+				$matcher = $regular_matcher;
+			}
+			elsif ($record =~ /\G([lu])(.)/gc) {
+				$debug and print "#   case $1 to <$2>\n";
+				push @path, $1 eq 'l' ? lc($2) : uc($2);
+			}
+			elsif (my @arg = grep {defined} $record =~ /\G$misc_matcher/gc) {
+				if ($] < 5.007) {
+					my $len = 0;
+					$len += length($_) for @arg;
+					$debug and print "#  pos ", pos($record), " fixup add $len\n";
+					pos($record) = pos($record) + $len;
+				}
+				my $directive = shift @arg;
+				if ($directive eq 'c') {
+					$debug and print "#  ctrl <@arg>\n";
+					push @path, "\\c" . uc(shift @arg);
+				}
+				else { # elsif ($directive eq '0') {
+					$debug and print "#  octal <@arg>\n";
+					my $ascii = oct(shift @arg);
+					push @path, ($ascii < 32)
+						? "\\c" . chr($ascii+64)
+						: chr($ascii)
+					;
+				}
+				$path[-1] .= join( '', @arg ); # if @arg;
+				redo;
+			}
+			elsif ($record =~ /\G(.)/gc) {
+				$token = $1;
+				$token =~ s{[AZabefnrtz\[\]{}()\\\$*+.?@|/^]}{\\$token};
+				$debug and print "#   meta <$token>\n";
+				push @path, $token;
+			}
+			else {
+				$debug and print "#   ignore char at ", pos($record), " of <$record>\n";
+			}
+			redo;
+		}
 
-        elsif ($record =~ /\G($class_matcher)($modifier)/gc) {
-            # [class] followed by a modifer
-            my $class     = $1;
-            my $qualifier = defined $2 ? $2 : '';
-            $debug and print "#  class begin <$class> <$qualifier>\n";
-            if ($class =~ /\A\[\\?(.)]\Z/) {
-                $class = quotemeta $1;
-                $class =~ s{\A\\([!@%])\Z}{$1};
-                $debug and print "#  class unwrap $class\n";
-            }
-            $debug and print "#  class end <$class> <$qualifier>\n";
-            push @path, ($unroll_plus and $qualifier =~ s/\A\+(\?)?\Z/*/)
-                ? ($class, "$class$qualifier" . (defined $1 ? $1 : ''))
-                : "$class$qualifier";
-            redo;
-        }
+		elsif ($record =~ /\G($class_matcher)($modifier)/gc) {
+			# [class] followed by a modifer
+			my $class     = $1;
+			my $qualifier = defined $2 ? $2 : '';
+			$debug and print "#  class begin <$class> <$qualifier>\n";
+			if ($class =~ /\A\[\\?(.)]\Z/) {
+				$class = quotemeta $1;
+				$class =~ s{\A\\([!@%])\Z}{$1};
+				$debug and print "#  class unwrap $class\n";
+			}
+			$debug and print "#  class end <$class> <$qualifier>\n";
+			push @path, ($unroll_plus and $qualifier =~ s/\A\+(\?)?\Z/*/)
+				? ($class, "$class$qualifier" . (defined $1 ? $1 : ''))
+				: "$class$qualifier";
+			redo;
+		}
 
-        elsif ($record =~ /\G($paren_matcher)/gc) {
-            $debug and print "#  paren <$1>\n";
-            # (paren) followed by a modifer
-            push @path, $1;
-            redo;
-        }
+		elsif ($record =~ /\G($paren_matcher)/gc) {
+			$debug and print "#  paren <$1>\n";
+			# (paren) followed by a modifer
+			push @path, $1;
+			redo;
+		}
 
-    }
-    return \@path;
+	}
+	return \@path;
 }
 
 sub _lex {
-    my $self   = shift;
-    my $record = shift;
-    my $len    = 0;
-    my @path   = ();
-    my $case   = '';
-    my $qm     = '';
-    my $re     = defined $self->{lex} ? $self->{lex}
-        : defined $Current_Lexer ? $Current_Lexer
-        : $Default_Lexer;
-    my $debug  = $self->{debug} & DEBUG_LEX;
-    $debug and print "# _lex <$record>\n";
-    my ($token, $next_token, $diff, $token_len);
-    while( $record =~ /($re)/g ) {
-        $token = $1;
-        $token_len = length($token);
-        $debug and print "# lexed <$token> len=$token_len\n";
-        if( pos($record) - $len > $token_len ) {
-            $next_token = $token;
-            $token = substr( $record, $len, $diff = pos($record) - $len - $token_len );
-            $debug and print "#  recover <", substr( $record, $len, $diff ), "> as <$token>, save <$next_token>\n";
-            $len += $diff;
-        }
-        $len += $token_len;
-        TOKEN: {
-            if( substr( $token, 0, 1 ) eq '\\' ) {
-                if( $token =~ /^\\([ELQU])$/ ) {
-                    if( $1 eq 'E' ) {
-                        $qm and $re = defined $self->{lex} ? $self->{lex}
-                            : defined $Current_Lexer ? $Current_Lexer
-                            : $Default_Lexer;
-                        $case = $qm = '';
-                    }
-                    elsif( $1 eq 'Q' ) {
-                        $qm = $1;
-                        # switch to a more precise lexer to quotemeta individual characters
-                        $re = qr/\\?./;
-                    }
-                    else {
-                        $case = $1;
-                    }
-                    $debug and print "#  state change qm=<$qm> case=<$case>\n";
-                    goto NEXT_TOKEN;
-                }
-                elsif( $token =~ /^\\([lu])(.)$/ ) {
-                    $debug and print "#  apply case=<$1> to <$2>\n";
-                    push @path, $1 eq 'l' ? lc($2) : uc($2);
-                    goto NEXT_TOKEN;
-                }
-                elsif( $token =~ /^\\x([\da-fA-F]{2})$/ ) {
-                    $token = quotemeta(chr(hex($1)));
-                    $debug and print "#  cooked <$token>\n";
-                    $token =~ s/^\\([^\w$()*+.?@\[\\\]^|{\/])$/$1/; # } balance
-                    $debug and print "#   giving <$token>\n";
-                }
-                else {
-                    $token =~ s/^\\([^\w$()*+.?@\[\\\]^|{\/])$/$1/; # } balance
-                    $debug and print "#  backslashed <$token>\n";
-                }
-            }
-            else {
-                $case and $token = $case eq 'U' ? uc($token) : lc($token);
-                $qm   and $token = quotemeta($token);
-                $token = '\\/' if $token eq '/';
-            }
-            # undo quotemeta's brute-force escapades
-            $qm and $token =~ s/^\\([^\w$()*+.?@\[\\\]^|{}\/])$/$1/;
-            $debug and print "#   <$token> case=<$case> qm=<$qm>\n";
-            push @path, $token;
+	my $self   = shift;
+	my $record = shift;
+	my $len    = 0;
+	my @path   = ();
+	my $case   = '';
+	my $qm     = '';
+	my $re     = defined $self->{lex} ? $self->{lex}
+		: defined $Current_Lexer ? $Current_Lexer
+		: $Default_Lexer;
+	my $debug  = $self->{debug} & DEBUG_LEX;
+	$debug and print "# _lex <$record>\n";
+	my ($token, $next_token, $diff, $token_len);
+	while( $record =~ /($re)/g ) {
+		$token = $1;
+		$token_len = length($token);
+		$debug and print "# lexed <$token> len=$token_len\n";
+		if( pos($record) - $len > $token_len ) {
+			$next_token = $token;
+			$token = substr( $record, $len, $diff = pos($record) - $len - $token_len );
+			$debug and print "#  recover <", substr( $record, $len, $diff ), "> as <$token>, save <$next_token>\n";
+			$len += $diff;
+		}
+		$len += $token_len;
+		TOKEN: {
+			if( substr( $token, 0, 1 ) eq '\\' ) {
+				if( $token =~ /^\\([ELQU])$/ ) {
+					if( $1 eq 'E' ) {
+						$qm and $re = defined $self->{lex} ? $self->{lex}
+							: defined $Current_Lexer ? $Current_Lexer
+							: $Default_Lexer;
+						$case = $qm = '';
+					}
+					elsif( $1 eq 'Q' ) {
+						$qm = $1;
+						# switch to a more precise lexer to quotemeta individual characters
+						$re = qr/\\?./;
+					}
+					else {
+						$case = $1;
+					}
+					$debug and print "#  state change qm=<$qm> case=<$case>\n";
+					goto NEXT_TOKEN;
+				}
+				elsif( $token =~ /^\\([lu])(.)$/ ) {
+					$debug and print "#  apply case=<$1> to <$2>\n";
+					push @path, $1 eq 'l' ? lc($2) : uc($2);
+					goto NEXT_TOKEN;
+				}
+				elsif( $token =~ /^\\x([\da-fA-F]{2})$/ ) {
+					$token = quotemeta(chr(hex($1)));
+					$debug and print "#  cooked <$token>\n";
+					$token =~ s/^\\([^\w$()*+.?@\[\\\]^|{\/])$/$1/; # } balance
+					$debug and print "#   giving <$token>\n";
+				}
+				else {
+					$token =~ s/^\\([^\w$()*+.?@\[\\\]^|{\/])$/$1/; # } balance
+					$debug and print "#  backslashed <$token>\n";
+				}
+			}
+			else {
+				$case and $token = $case eq 'U' ? uc($token) : lc($token);
+				$qm   and $token = quotemeta($token);
+				$token = '\\/' if $token eq '/';
+			}
+			# undo quotemeta's brute-force escapades
+			$qm and $token =~ s/^\\([^\w$()*+.?@\[\\\]^|{}\/])$/$1/;
+			$debug and print "#   <$token> case=<$case> qm=<$qm>\n";
+			push @path, $token;
 
-            NEXT_TOKEN:
-            if( defined $next_token ) {
-                $debug and print "#   redo <$next_token>\n";
-                $token = $next_token;
-                $next_token = undef;
-                redo TOKEN;
-            }
-        }
-    }
-    if( $len < length($record) ) {
-        # NB: the remainder only arises in the case of degenerate lexer,
-        # and if \Q is operative, the lexer will have been switched to
-        # /\\?./, which means there can never be a remainder, so we
-        # don't have to bother about quotemeta. In other words:
-        # $qm will never be true in this block.
-        my $remain = substr($record,$len);
-        $case and $remain = $case eq 'U' ? uc($remain) : lc($remain);
-        $debug and print "#   add remaining <$remain> case=<$case> qm=<$qm>\n";
-        push @path, $remain;
-    }
-    $debug and print "# _lex out <@path>\n";
-    return \@path;
+			NEXT_TOKEN:
+			if( defined $next_token ) {
+				$debug and print "#   redo <$next_token>\n";
+				$token = $next_token;
+				$next_token = undef;
+				redo TOKEN;
+			}
+		}
+	}
+	if( $len < length($record) ) {
+		# NB: the remainder only arises in the case of degenerate lexer,
+		# and if \Q is operative, the lexer will have been switched to
+		# /\\?./, which means there can never be a remainder, so we
+		# don't have to bother about quotemeta. In other words:
+		# $qm will never be true in this block.
+		my $remain = substr($record,$len);
+		$case and $remain = $case eq 'U' ? uc($remain) : lc($remain);
+		$debug and print "#   add remaining <$remain> case=<$case> qm=<$qm>\n";
+		push @path, $remain;
+	}
+	$debug and print "# _lex out <@path>\n";
+	return \@path;
 }
 
 sub add {
-    my $self = shift;
-    my $record;
-    my $debug  = $self->{debug} & DEBUG_LEX;
-    while( defined( $record = shift @_ )) {
-        CORE::chomp($record) if $self->{chomp};
-        next if $self->{pre_filter} and not $self->{pre_filter}->($record);
-        $debug and print "# add <$record>\n";
-        $self->{stats_raw} += length $record;
-        my $list = $record =~ /[+*?(\\\[{]/ # }]) restore equilibrium
-            ? $self->{lex} ? $self->_lex($record) : $self->_fastlex($record)
-            : [split //, $record]
-        ;
-        next if $self->{filter} and not $self->{filter}->(@$list);
-        $self->_insertr( $list );
-    }
-    return $self;
+	my $self = shift;
+	my $record;
+	my $debug  = $self->{debug} & DEBUG_LEX;
+	while( defined( $record = shift @_ )) {
+		CORE::chomp($record) if $self->{chomp};
+		next if $self->{pre_filter} and not $self->{pre_filter}->($record);
+		$debug and print "# add <$record>\n";
+		$self->{stats_raw} += length $record;
+		my $list = $record =~ /[+*?(\\\[{]/ # }]) restore equilibrium
+			? $self->{lex} ? $self->_lex($record) : $self->_fastlex($record)
+			: [split //, $record]
+		;
+		next if $self->{filter} and not $self->{filter}->(@$list);
+		$self->_insertr( $list );
+	}
+	return $self;
 }
 
 sub add_file {
-    my $self = shift;
-    my $rs;
-    my @file;
-    if (ref($_[0]) eq 'HASH') {
-        my $arg = shift;
-        $rs = $arg->{rs}
-            || $arg->{input_record_separator}
-            || $self->{input_record_separator}
-            || $/;
-        @file = ref($arg->{file}) eq 'ARRAY'
-            ? @{$arg->{file}}
-            : $arg->{file};
-    }
-    else {
-        $rs   = $self->{input_record_separator} || $/;
-        @file = @_;
-    }
-    local $/ = $rs;
-    my $file;
-    for $file (@file) {
-        open my $fh, '<', $file or do {
-            require Carp;
-            Carp::croak("cannot open $file for input: $!");
-        };
-        while (defined (my $rec = <$fh>)) {
-            $self->add($rec);
-        }
-        close $fh;
-    }
-    return $self;
+	my $self = shift;
+	my $rs;
+	my @file;
+	if (ref($_[0]) eq 'HASH') {
+		my $arg = shift;
+		$rs = $arg->{rs}
+			|| $arg->{input_record_separator}
+			|| $self->{input_record_separator}
+			|| $/;
+		@file = ref($arg->{file}) eq 'ARRAY'
+			? @{$arg->{file}}
+			: $arg->{file};
+	}
+	else {
+		$rs   = $self->{input_record_separator} || $/;
+		@file = @_;
+	}
+	local $/ = $rs;
+	my $file;
+	for $file (@file) {
+		open my $fh, '<', $file or do {
+			require Carp;
+			Carp::croak("cannot open $file for input: $!");
+		};
+		while (defined (my $rec = <$fh>)) {
+			$self->add($rec);
+		}
+		close $fh;
+	}
+	return $self;
 }
 
 sub insert {
-    my $self = shift;
-    return if $self->{filter} and not $self->{filter}->(@_);
-    $self->_insertr( [@_] );
-    return $self;
+	my $self = shift;
+	return if $self->{filter} and not $self->{filter}->(@_);
+	$self->_insertr( [@_] );
+	return $self;
 }
 
 sub _insertr {
-    my $self   = shift;
-    my $dup    = $self->{stats_dup} || 0;
-    $self->{path} = $self->_insert_path( $self->_path, $self->_debug(DEBUG_ADD), $_[0] );
-    if( not defined $self->{stats_dup} or $dup == $self->{stats_dup} ) {
-        ++$self->{stats_add};
-        $self->{stats_cooked} += defined($_) ? length($_) : 0 for @{$_[0]};
-    }
-    elsif( $self->{dup_warn} ) {
-        if( ref $self->{dup_warn} eq 'CODE' ) {
-            $self->{dup_warn}->($self, $_[0]);
-        }
-        else {
-            my $pattern = join( '', @{$_[0]} );
-            require Carp;
-            Carp::carp("duplicate pattern added: /$pattern/");
-        }
-    }
-    $self->{str} = $self->{re} = undef;
+	my $self   = shift;
+	my $dup    = $self->{stats_dup} || 0;
+	$self->{path} = $self->_insert_path( $self->_path, $self->_debug(DEBUG_ADD), $_[0] );
+	if( not defined $self->{stats_dup} or $dup == $self->{stats_dup} ) {
+		++$self->{stats_add};
+		$self->{stats_cooked} += defined($_) ? length($_) : 0 for @{$_[0]};
+	}
+	elsif( $self->{dup_warn} ) {
+		if( ref $self->{dup_warn} eq 'CODE' ) {
+			$self->{dup_warn}->($self, $_[0]);
+		}
+		else {
+			my $pattern = join( '', @{$_[0]} );
+			require Carp;
+			Carp::carp("duplicate pattern added: /$pattern/");
+		}
+	}
+	$self->{str} = $self->{re} = undef;
 }
 
 sub lexstr {
-    return shift->_lex(shift);
+	return shift->_lex(shift);
 }
 
 sub pre_filter {
-    my $self   = shift;
-    my $pre_filter = shift;
-    if( defined $pre_filter and ref($pre_filter) ne 'CODE' ) {
-        require Carp;
-        Carp::croak("pre_filter method not passed a coderef");
-    }
-    $self->{pre_filter} = $pre_filter;
-    return $self;
+	my $self   = shift;
+	my $pre_filter = shift;
+	if( defined $pre_filter and ref($pre_filter) ne 'CODE' ) {
+		require Carp;
+		Carp::croak("pre_filter method not passed a coderef");
+	}
+	$self->{pre_filter} = $pre_filter;
+	return $self;
 }
 
 
 sub filter {
-    my $self   = shift;
-    my $filter = shift;
-    if( defined $filter and ref($filter) ne 'CODE' ) {
-        require Carp;
-        Carp::croak("filter method not passed a coderef");
-    }
-    $self->{filter} = $filter;
-    return $self;
+	my $self   = shift;
+	my $filter = shift;
+	if( defined $filter and ref($filter) ne 'CODE' ) {
+		require Carp;
+		Carp::croak("filter method not passed a coderef");
+	}
+	$self->{filter} = $filter;
+	return $self;
 }
 
 sub as_string {
-    my $self = shift;
-    if( not defined $self->{str} ) {
-        if( $self->{track} ) {
-            $self->{m}      = undef;
-            $self->{mcount} = 0;
-            $self->{mlist}  = [];
-            $self->{str}    = _re_path_track($self, $self->_path, '', '');
-        }
-        else {
-            $self->_reduce unless ($self->{mutable} or not $self->{reduce});
-            my $arg  = {@_};
-            $arg->{indent} = $self->{indent}
-                if not exists $arg->{indent} and $self->{indent} > 0;
-            if( exists $arg->{indent} and $arg->{indent} > 0 ) {
-                $arg->{depth} = 0;
-                $self->{str}  = _re_path_pretty($self, $self->_path, $arg);
-            }
-            elsif( $self->{lookahead} ) {
-                $self->{str}  = _re_path_lookahead($self, $self->_path);
-            }
-            else {
-                $self->{str}  = _re_path($self, $self->_path);
-            }
-        }
-        if (not length $self->{str}) {
-            # explicitly fail to match anything if no pattern was generated
-            $self->{str} = $Always_Fail;
-        }
-        else {
-            my $begin =
-                  $self->{anchor_word_begin}   ? '\\b'
-                : $self->{anchor_line_begin}   ? '^'
-                : $self->{anchor_string_begin} ? '\A'
-                : ''
-            ;
-            my $end =
-                  $self->{anchor_word_end}            ? '\\b'
-                : $self->{anchor_line_end}            ? '$'
-                : $self->{anchor_string_end}          ? '\Z'
-                : $self->{anchor_string_end_absolute} ? '\z'
-                : ''
-            ;
-            $self->{str} = "$begin$self->{str}$end";
-        }
-        $self->{path} = [] unless $self->{mutable};
-    }
-    return $self->{str};
+	my $self = shift;
+	if( not defined $self->{str} ) {
+		if( $self->{track} ) {
+			$self->{m}      = undef;
+			$self->{mcount} = 0;
+			$self->{mlist}  = [];
+			$self->{str}    = _re_path_track($self, $self->_path, '', '');
+		}
+		else {
+			$self->_reduce unless ($self->{mutable} or not $self->{reduce});
+			my $arg  = {@_};
+			$arg->{indent} = $self->{indent}
+				if not exists $arg->{indent} and $self->{indent} > 0;
+			if( exists $arg->{indent} and $arg->{indent} > 0 ) {
+				$arg->{depth} = 0;
+				$self->{str}  = _re_path_pretty($self, $self->_path, $arg);
+			}
+			elsif( $self->{lookahead} ) {
+				$self->{str}  = _re_path_lookahead($self, $self->_path);
+			}
+			else {
+				$self->{str}  = _re_path($self, $self->_path);
+			}
+		}
+		if (not length $self->{str}) {
+			# explicitly fail to match anything if no pattern was generated
+			$self->{str} = $Always_Fail;
+		}
+		else {
+			my $begin =
+				  $self->{anchor_word_begin}   ? '\\b'
+				: $self->{anchor_line_begin}   ? '^'
+				: $self->{anchor_string_begin} ? '\A'
+				: ''
+			;
+			my $end =
+				  $self->{anchor_word_end}            ? '\\b'
+				: $self->{anchor_line_end}            ? '$'
+				: $self->{anchor_string_end}          ? '\Z'
+				: $self->{anchor_string_end_absolute} ? '\z'
+				: ''
+			;
+			$self->{str} = "$begin$self->{str}$end";
+		}
+		$self->{path} = [] unless $self->{mutable};
+	}
+	return $self->{str};
 }
 
 sub re {
-    my $self = shift;
-    $self->_build_re($self->as_string(@_)) unless defined $self->{re};
-    return $self->{re};
+	my $self = shift;
+	$self->_build_re($self->as_string(@_)) unless defined $self->{re};
+	return $self->{re};
 }
 
 use overload '""' => sub {
-    my $self = shift;
-    return $self->{re} if $self->{re};
-    $self->_build_re($self->as_string());
-    return $self->{re};
+	my $self = shift;
+	return $self->{re} if $self->{re};
+	$self->_build_re($self->as_string());
+	return $self->{re};
 };
 
 sub _build_re {
-    my $self  = shift;
-    my $str   = shift;
-    if( $self->{track} ) {
-        use re 'eval';
-        $self->{re} = length $self->{flags}
-            ? qr/(?$self->{flags}:$str)/
-            : qr/$str/
-        ;
-    }
-    else {
-        # how could I not repeat myself?
-        $self->{re} = length $self->{flags}
-            ? qr/(?$self->{flags}:$str)/
-            : qr/$str/
-        ;
-    }
+	my $self  = shift;
+	my $str   = shift;
+	if( $self->{track} ) {
+		use re 'eval';
+		$self->{re} = length $self->{flags}
+			? qr/(?$self->{flags}:$str)/
+			: qr/$str/
+		;
+	}
+	else {
+		# how could I not repeat myself?
+		$self->{re} = length $self->{flags}
+			? qr/(?$self->{flags}:$str)/
+			: qr/$str/
+		;
+	}
 }
 
 sub match {
-    my $self = shift;
-    my $target = shift;
-    $self->_build_re($self->as_string(@_)) unless defined $self->{re};
-    $self->{m}    = undef;
-    $self->{mvar} = [];
-    if( not $target =~ /$self->{re}/ ) {
-        $self->{mbegin} = [];
-        $self->{mend}   = [];
-        return undef;
-    }
-    $self->{m}      = $^R if $] >= 5.009005;
-    $self->{mbegin} = _path_copy([@-]);
-    $self->{mend}   = _path_copy([@+]);
-    my $n = 0;
-    for( my $n = 0; $n < @-; ++$n ) {
-        push @{$self->{mvar}}, substr($target, $-[$n], $+[$n] - $-[$n])
-            if defined $-[$n] and defined $+[$n];
-    }
-    if( $self->{track} ) {
-        return defined $self->{m} ? $self->{mlist}[$self->{m}] : 1;
-    }
-    else {
-        return 1;
-    }
+	my $self = shift;
+	my $target = shift;
+	$self->_build_re($self->as_string(@_)) unless defined $self->{re};
+	$self->{m}    = undef;
+	$self->{mvar} = [];
+	if( not $target =~ /$self->{re}/ ) {
+		$self->{mbegin} = [];
+		$self->{mend}   = [];
+		return undef;
+	}
+	$self->{m}      = $^R if $] >= 5.009005;
+	$self->{mbegin} = _path_copy([@-]);
+	$self->{mend}   = _path_copy([@+]);
+	my $n = 0;
+	for( my $n = 0; $n < @-; ++$n ) {
+		push @{$self->{mvar}}, substr($target, $-[$n], $+[$n] - $-[$n])
+			if defined $-[$n] and defined $+[$n];
+	}
+	if( $self->{track} ) {
+		return defined $self->{m} ? $self->{mlist}[$self->{m}] : 1;
+	}
+	else {
+		return 1;
+	}
 }
 
 sub source {
-    my $self = shift;
-    return unless $self->{track};
-    defined($_[0]) and return $self->{mlist}[$_[0]];
-    return unless defined $self->{m};
-    return $self->{mlist}[$self->{m}];
+	my $self = shift;
+	return unless $self->{track};
+	defined($_[0]) and return $self->{mlist}[$_[0]];
+	return unless defined $self->{m};
+	return $self->{mlist}[$self->{m}];
 }
 
 sub mbegin {
-    my $self = shift;
-    return exists $self->{mbegin} ? $self->{mbegin} : [];
+	my $self = shift;
+	return exists $self->{mbegin} ? $self->{mbegin} : [];
 }
 
 sub mend {
-    my $self = shift;
-    return exists $self->{mend} ? $self->{mend} : [];
+	my $self = shift;
+	return exists $self->{mend} ? $self->{mend} : [];
 }
 
 sub mvar {
-    my $self = shift;
-    return undef unless exists $self->{mvar};
-    return defined($_[0]) ? $self->{mvar}[$_[0]] : $self->{mvar};
+	my $self = shift;
+	return undef unless exists $self->{mvar};
+	return defined($_[0]) ? $self->{mvar}[$_[0]] : $self->{mvar};
 }
 
 sub capture {
-    my $self = shift;
-    if( $self->{mvar} ) {
-        my @capture = @{$self->{mvar}};
-        shift @capture;
-        return @capture;
-    }
-    return ();
+	my $self = shift;
+	if( $self->{mvar} ) {
+		my @capture = @{$self->{mvar}};
+		shift @capture;
+		return @capture;
+	}
+	return ();
 }
 
 sub matched {
-    my $self = shift;
-    return defined $self->{m} ? $self->{mlist}[$self->{m}] : undef;
+	my $self = shift;
+	return defined $self->{m} ? $self->{mlist}[$self->{m}] : undef;
 }
 
 sub stats_add {
-    my $self = shift;
-    return $self->{stats_add} || 0;
+	my $self = shift;
+	return $self->{stats_add} || 0;
 }
 
 sub stats_dup {
-    my $self = shift;
-    return $self->{stats_dup} || 0;
+	my $self = shift;
+	return $self->{stats_dup} || 0;
 }
 
 sub stats_raw {
-    my $self = shift;
-    return $self->{stats_raw} || 0;
+	my $self = shift;
+	return $self->{stats_raw} || 0;
 }
 
 sub stats_cooked {
-    my $self = shift;
-    return $self->{stats_cooked} || 0;
+	my $self = shift;
+	return $self->{stats_cooked} || 0;
 }
 
 sub stats_length {
-    my $self = shift;
-    return (defined $self->{str} and $self->{str} ne $Always_Fail) ? length $self->{str} : 0;
+	my $self = shift;
+	return (defined $self->{str} and $self->{str} ne $Always_Fail) ? length $self->{str} : 0;
 }
 
 sub dup_warn {
-    my $self = shift;
-    $self->{dup_warn} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{dup_warn} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub anchor_word_begin {
-    my $self = shift;
-    $self->{anchor_word_begin} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{anchor_word_begin} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub anchor_word_end {
-    my $self = shift;
-    $self->{anchor_word_end} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{anchor_word_end} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub anchor_word {
-    my $self  = shift;
-    my $state = shift;
-    $self->anchor_word_begin($state)->anchor_word_end($state);
-    return $self;
+	my $self  = shift;
+	my $state = shift;
+	$self->anchor_word_begin($state)->anchor_word_end($state);
+	return $self;
 }
 
 sub anchor_line_begin {
-    my $self = shift;
-    $self->{anchor_line_begin} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{anchor_line_begin} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub anchor_line_end {
-    my $self = shift;
-    $self->{anchor_line_end} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{anchor_line_end} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub anchor_line {
-    my $self  = shift;
-    my $state = shift;
-    $self->anchor_line_begin($state)->anchor_line_end($state);
-    return $self;
+	my $self  = shift;
+	my $state = shift;
+	$self->anchor_line_begin($state)->anchor_line_end($state);
+	return $self;
 }
 
 sub anchor_string_begin {
-    my $self = shift;
-    $self->{anchor_string_begin} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{anchor_string_begin} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub anchor_string_end {
-    my $self = shift;
-    $self->{anchor_string_end} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{anchor_string_end} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub anchor_string_end_absolute {
-    my $self = shift;
-    $self->{anchor_string_end_absolute} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{anchor_string_end_absolute} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub anchor_string {
-    my $self  = shift;
-    my $state = defined($_[0]) ? $_[0] : 1;
-    $self->anchor_string_begin($state)->anchor_string_end($state);
-    return $self;
+	my $self  = shift;
+	my $state = defined($_[0]) ? $_[0] : 1;
+	$self->anchor_string_begin($state)->anchor_string_end($state);
+	return $self;
 }
 
 sub anchor_string_absolute {
-    my $self  = shift;
-    my $state = defined($_[0]) ? $_[0] : 1;
-    $self->anchor_string_begin($state)->anchor_string_end_absolute($state);
-    return $self;
+	my $self  = shift;
+	my $state = defined($_[0]) ? $_[0] : 1;
+	$self->anchor_string_begin($state)->anchor_string_end_absolute($state);
+	return $self;
 }
 
 sub debug {
-    my $self = shift;
-    $self->{debug} = defined($_[0]) ? $_[0] : 0;
-    if ($self->_debug(DEBUG_TIME)) {
-        # hmm, debugging time was switched on after instantiation
-        $self->_init_time_func;
-        $self->{_begin_time} = $self->{_time_func}->();
-    }
-    return $self;
+	my $self = shift;
+	$self->{debug} = defined($_[0]) ? $_[0] : 0;
+	if ($self->_debug(DEBUG_TIME)) {
+		# hmm, debugging time was switched on after instantiation
+		$self->_init_time_func;
+		$self->{_begin_time} = $self->{_time_func}->();
+	}
+	return $self;
 }
 
 sub dump {
-    return _dump($_[0]->_path);
+	return _dump($_[0]->_path);
 }
 
 sub chomp {
-    my $self = shift;
-    $self->{chomp} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{chomp} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub fold_meta_pairs {
-    my $self = shift;
-    $self->{fold_meta_pairs} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{fold_meta_pairs} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub indent {
-    my $self = shift;
-    $self->{indent} = defined($_[0]) ? $_[0] : 0;
-    return $self;
+	my $self = shift;
+	$self->{indent} = defined($_[0]) ? $_[0] : 0;
+	return $self;
 }
 
 sub lookahead {
-    my $self = shift;
-    $self->{lookahead} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{lookahead} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub flags {
-    my $self = shift;
-    $self->{flags} = defined($_[0]) ? $_[0] : '';
-    return $self;
+	my $self = shift;
+	$self->{flags} = defined($_[0]) ? $_[0] : '';
+	return $self;
 }
 
 sub modifiers {
-    my $self = shift;
-    return $self->flags(@_);
+	my $self = shift;
+	return $self->flags(@_);
 }
 
 sub track {
-    my $self = shift;
-    $self->{track} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{track} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub unroll_plus {
-    my $self = shift;
-    $self->{unroll_plus} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{unroll_plus} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub lex {
-    my $self = shift;
-    $self->{lex} = qr($_[0]);
-    return $self;
+	my $self = shift;
+	$self->{lex} = qr($_[0]);
+	return $self;
 }
 
 sub reduce {
-    my $self = shift;
-    $self->{reduce} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{reduce} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub mutable {
-    my $self = shift;
-    $self->{mutable} = defined($_[0]) ? $_[0] : 1;
-    return $self;
+	my $self = shift;
+	$self->{mutable} = defined($_[0]) ? $_[0] : 1;
+	return $self;
 }
 
 sub reset {
-    # reinitialise the internal state of the object
-    my $self = shift;
-    $self->{path} = [];
-    $self->{re}   = undef;
-    $self->{str}  = undef;
-    return $self;
+	# reinitialise the internal state of the object
+	my $self = shift;
+	$self->{path} = [];
+	$self->{re}   = undef;
+	$self->{str}  = undef;
+	return $self;
 }
 
 sub Default_Lexer {
-    if( $_[0] ) {
-        if( my $refname = ref($_[0]) ) {
-            require Carp;
-            Carp::croak("Cannot pass a $refname to Default_Lexer");
-        }
-        $Current_Lexer = $_[0];
-    }
-    return defined $Current_Lexer ? $Current_Lexer : $Default_Lexer;
+	if( $_[0] ) {
+		if( my $refname = ref($_[0]) ) {
+			require Carp;
+			Carp::croak("Cannot pass a $refname to Default_Lexer");
+		}
+		$Current_Lexer = $_[0];
+	}
+	return defined $Current_Lexer ? $Current_Lexer : $Default_Lexer;
 }
 
 # --- no user serviceable parts below ---
@@ -835,1148 +835,1148 @@ sub Default_Lexer {
 # -- debug helpers
 
 sub _debug {
-    my $self = shift;
-    return $self->{debug} & shift() ? 1 : 0;
+	my $self = shift;
+	return $self->{debug} & shift() ? 1 : 0;
 }
 
 # -- helpers
 
 sub _path {
-    # access the path
-    return $_[0]->{path};
+	# access the path
+	return $_[0]->{path};
 }
 
 # -- the heart of the matter
 
 $have_Storable = do {
-    eval {
-        require Storable;
-        import Storable 'dclone';
-    };
-    $@ ? 0 : 1;
+	eval {
+		require Storable;
+		import Storable 'dclone';
+	};
+	$@ ? 0 : 1;
 };
 
 sub _path_clone {
-    $have_Storable ? dclone($_[0]) : _path_copy($_[0]);
+	$have_Storable ? dclone($_[0]) : _path_copy($_[0]);
 }
 
 sub _path_copy {
-    my $path = shift;
-    my $new  = [];
-    for( my $p = 0; $p < @$path; ++$p ) {
-        if( ref($path->[$p]) eq 'HASH' ) {
-            push @$new, _node_copy($path->[$p]);
-        }
-        elsif( ref($path->[$p]) eq 'ARRAY' ) {
-            push @$new, _path_copy($path->[$p]);
-        }
-        else {
-            push @$new, $path->[$p];
-        }
-    }
-    return $new;
+	my $path = shift;
+	my $new  = [];
+	for( my $p = 0; $p < @$path; ++$p ) {
+		if( ref($path->[$p]) eq 'HASH' ) {
+			push @$new, _node_copy($path->[$p]);
+		}
+		elsif( ref($path->[$p]) eq 'ARRAY' ) {
+			push @$new, _path_copy($path->[$p]);
+		}
+		else {
+			push @$new, $path->[$p];
+		}
+	}
+	return $new;
 }
 
 sub _node_copy {
-    my $node = shift;
-    my $new  = {};
-    while( my( $k, $v ) = each %$node ) {
-        $new->{$k} = defined($v)
-            ? _path_copy($v)
-            : undef
-        ;
-    }
-    return $new;
+	my $node = shift;
+	my $new  = {};
+	while( my( $k, $v ) = each %$node ) {
+		$new->{$k} = defined($v)
+			? _path_copy($v)
+			: undef
+		;
+	}
+	return $new;
 }
 
 sub _insert_path {
-    my $self  = shift;
-    my $list  = shift;
-    my $debug = shift;
-    my @in    = @{shift()}; # create a new copy
-    if( @$list == 0 ) { # special case the first time
-        if( @in == 0 or (@in == 1 and (not defined $in[0] or $in[0] eq ''))) {
-            return [{'' => undef}];
-        }
-        else {
-            return \@in;
-        }
-    }
-    $debug and print "# _insert_path @{[_dump(\@in)]} into @{[_dump($list)]}\n";
-    my $path   = $list;
-    my $offset = 0;
-    my $token;
-    if( not @in ) {
-        if( ref($list->[0]) ne 'HASH' ) {
-            return [ { '' => undef, $list->[0] => $list } ];
-        }
-        else {
-            $list->[0]{''} = undef;
-            return $list;
-        }
-    }
-    while( defined( $token = shift @in )) {
-        if( ref($token) eq 'HASH' ) {
-            $debug and print "#  p0=", _dump($path), "\n";
-            $path = $self->_insert_node( $path, $offset, $token, $debug, @in );
-            $debug and print "#  p1=", _dump($path), "\n";
-            last;
-        }
-        if( ref($path->[$offset]) eq 'HASH' ) {
-            $debug and print "#   at (off=$offset len=@{[scalar @$path]}) ", _dump($path->[$offset]), "\n";
-            my $node = $path->[$offset];
-            if( exists( $node->{$token} )) {
-                if ($offset < $#$path) {
-                    my $new = {
-                        $token => [$token, @in],
-                        _re_path($self, [$node]) => [@{$path}[$offset..$#$path]],
-                    };
-                    splice @$path, $offset, @$path-$offset, $new;
-                    last;
-                }
-                else {
-                    $debug and print "#   descend key=$token @{[_dump($node->{$token})]}\n";
-                    $path   = $node->{$token};
-                    $offset = 0;
-                    redo;
-                }
-            }
-            else {
-                $debug and print "#   add path ($token:@{[_dump(\@in)]}) into @{[_dump($path)]} at off=$offset to end=@{[scalar $#$path]}\n";
-                if( $offset == $#$path ) {
-                    $node->{$token} = [ $token, @in ];
-                }
-                else {
-                    my $new = {
-                        _node_key($token) => [ $token, @in ],
-                        _node_key($node)  => [@{$path}[$offset..$#{$path}]],
-                    };
-                    splice( @$path, $offset, @$path - $offset, $new );
-                    $debug and print "#   fused node=@{[_dump($new)]} path=@{[_dump($path)]}\n";
-                }
-                last;
-            }
-        }
+	my $self  = shift;
+	my $list  = shift;
+	my $debug = shift;
+	my @in    = @{shift()}; # create a new copy
+	if( @$list == 0 ) { # special case the first time
+		if( @in == 0 or (@in == 1 and (not defined $in[0] or $in[0] eq ''))) {
+			return [{'' => undef}];
+		}
+		else {
+			return \@in;
+		}
+	}
+	$debug and print "# _insert_path @{[_dump(\@in)]} into @{[_dump($list)]}\n";
+	my $path   = $list;
+	my $offset = 0;
+	my $token;
+	if( not @in ) {
+		if( ref($list->[0]) ne 'HASH' ) {
+			return [ { '' => undef, $list->[0] => $list } ];
+		}
+		else {
+			$list->[0]{''} = undef;
+			return $list;
+		}
+	}
+	while( defined( $token = shift @in )) {
+		if( ref($token) eq 'HASH' ) {
+			$debug and print "#  p0=", _dump($path), "\n";
+			$path = $self->_insert_node( $path, $offset, $token, $debug, @in );
+			$debug and print "#  p1=", _dump($path), "\n";
+			last;
+		}
+		if( ref($path->[$offset]) eq 'HASH' ) {
+			$debug and print "#   at (off=$offset len=@{[scalar @$path]}) ", _dump($path->[$offset]), "\n";
+			my $node = $path->[$offset];
+			if( exists( $node->{$token} )) {
+				if ($offset < $#$path) {
+					my $new = {
+						$token => [$token, @in],
+						_re_path($self, [$node]) => [@{$path}[$offset..$#$path]],
+					};
+					splice @$path, $offset, @$path-$offset, $new;
+					last;
+				}
+				else {
+					$debug and print "#   descend key=$token @{[_dump($node->{$token})]}\n";
+					$path   = $node->{$token};
+					$offset = 0;
+					redo;
+				}
+			}
+			else {
+				$debug and print "#   add path ($token:@{[_dump(\@in)]}) into @{[_dump($path)]} at off=$offset to end=@{[scalar $#$path]}\n";
+				if( $offset == $#$path ) {
+					$node->{$token} = [ $token, @in ];
+				}
+				else {
+					my $new = {
+						_node_key($token) => [ $token, @in ],
+						_node_key($node)  => [@{$path}[$offset..$#{$path}]],
+					};
+					splice( @$path, $offset, @$path - $offset, $new );
+					$debug and print "#   fused node=@{[_dump($new)]} path=@{[_dump($path)]}\n";
+				}
+				last;
+			}
+		}
 
-        if( $debug ) {
-            my $msg = '';
-            my $n;
-            for( $n = 0; $n < @$path; ++$n ) {
-                $msg .= ' ' if $n;
-                my $atom = ref($path->[$n]) eq 'HASH'
-                    ? '{'.join( ' ', keys(%{$path->[$n]})).'}'
-                    : $path->[$n]
-                ;
-                $msg .= $n == $offset ? "<$atom>" : $atom;
-            }
-            print "# at path ($msg)\n";
-        }
+		if( $debug ) {
+			my $msg = '';
+			my $n;
+			for( $n = 0; $n < @$path; ++$n ) {
+				$msg .= ' ' if $n;
+				my $atom = ref($path->[$n]) eq 'HASH'
+					? '{'.join( ' ', keys(%{$path->[$n]})).'}'
+					: $path->[$n]
+				;
+				$msg .= $n == $offset ? "<$atom>" : $atom;
+			}
+			print "# at path ($msg)\n";
+		}
 
-        if( $offset >= @$path ) {
-            push @$path, { $token => [ $token, @in ], '' => undef };
-            $debug and print "#   added remaining @{[_dump($path)]}\n";
-            last;
-        }
-        elsif( $token ne $path->[$offset] ) {
-            $debug and print "#   token $token not present\n";
-            splice @$path, $offset, @$path-$offset, {
-                length $token
-                    ? ( _node_key($token) => [$token, @in])
-                    : ( '' => undef )
-                ,
-                $path->[$offset] => [@{$path}[$offset..$#{$path}]],
-            };
-            $debug and print "#   path=@{[_dump($path)]}\n";
-            last;
-        }
-        elsif( not @in ) {
-            $debug and print "#   last token to add\n";
-            if( defined( $path->[$offset+1] )) {
-                ++$offset;
-                if( ref($path->[$offset]) eq 'HASH' ) {
-                    $debug and print "#   add sentinel to node\n";
-                    $path->[$offset]{''} = undef;
-                }
-                else {
-                    $debug and print "#   convert <$path->[$offset]> to node for sentinel\n";
-                    splice @$path, $offset, @$path-$offset, {
-                        ''               => undef,
-                        $path->[$offset] => [ @{$path}[$offset..$#{$path}] ],
-                    };
-                }
-            }
-            else {
-                # already seen this pattern
-                ++$self->{stats_dup};
-            }
-            last;
-        }
-        # if we get here then @_ still contains a token
-        ++$offset;
-    }
-    $list;
+		if( $offset >= @$path ) {
+			push @$path, { $token => [ $token, @in ], '' => undef };
+			$debug and print "#   added remaining @{[_dump($path)]}\n";
+			last;
+		}
+		elsif( $token ne $path->[$offset] ) {
+			$debug and print "#   token $token not present\n";
+			splice @$path, $offset, @$path-$offset, {
+				length $token
+					? ( _node_key($token) => [$token, @in])
+					: ( '' => undef )
+				,
+				$path->[$offset] => [@{$path}[$offset..$#{$path}]],
+			};
+			$debug and print "#   path=@{[_dump($path)]}\n";
+			last;
+		}
+		elsif( not @in ) {
+			$debug and print "#   last token to add\n";
+			if( defined( $path->[$offset+1] )) {
+				++$offset;
+				if( ref($path->[$offset]) eq 'HASH' ) {
+					$debug and print "#   add sentinel to node\n";
+					$path->[$offset]{''} = undef;
+				}
+				else {
+					$debug and print "#   convert <$path->[$offset]> to node for sentinel\n";
+					splice @$path, $offset, @$path-$offset, {
+						''               => undef,
+						$path->[$offset] => [ @{$path}[$offset..$#{$path}] ],
+					};
+				}
+			}
+			else {
+				# already seen this pattern
+				++$self->{stats_dup};
+			}
+			last;
+		}
+		# if we get here then @_ still contains a token
+		++$offset;
+	}
+	$list;
 }
 
 sub _insert_node {
-    my $self   = shift;
-    my $path   = shift;
-    my $offset = shift;
-    my $token  = shift;
-    my $debug  = shift;
-    my $path_end = [@{$path}[$offset..$#{$path}]];
-    # NB: $path->[$offset] and $[path_end->[0] are equivalent
-    my $token_key = _re_path($self, [$token]);
-    $debug and print "#  insert node(@{[_dump($token)]}:@{[_dump(\@_)]}) (key=$token_key)",
-        " at path=@{[_dump($path_end)]}\n";
-    if( ref($path_end->[0]) eq 'HASH' ) {
-        if( exists($path_end->[0]{$token_key}) ) {
-            if( @$path_end > 1 ) {
-                my $path_key = _re_path($self, [$path_end->[0]]);
-                my $new = {
-                    $path_key  => [ @$path_end ],
-                    $token_key => [ $token, @_ ],
-                };
-                $debug and print "#   +bifurcate new=@{[_dump($new)]}\n";
-                splice( @$path, $offset, @$path_end, $new );
-            }
-            else {
-                my $old_path = $path_end->[0]{$token_key};
-                my $new_path = [];
-                while( @$old_path and _node_eq( $old_path->[0], $token )) {
-                    $debug and print "#  identical nodes in sub_path ",
-                        ref($token) ? _dump($token) : $token, "\n";
-                    push @$new_path, shift(@$old_path);
-                    $token = shift @_;
-                }
-                if( @$new_path ) {
-                    my $new;
-                    my $token_key = $token;
-                    if( @_ ) {
-                        $new = {
-                            _re_path($self, $old_path) => $old_path,
-                            $token_key => [$token, @_],
-                        };
-                        $debug and print "#  insert_node(bifurc) n=@{[_dump([$new])]}\n";
-                    }
-                    else {
-                        $debug and print "#  insert $token into old path @{[_dump($old_path)]}\n";
-                        if( @$old_path ) {
-                            $new = ($self->_insert_path( $old_path, $debug, [$token] ))->[0];
-                        }
-                        else {
-                            $new = { '' => undef, $token => [$token] };
-                        }
-                    }
-                    push @$new_path, $new;
-                }
-                $path_end->[0]{$token_key} = $new_path;
-                $debug and print "#   +_insert_node result=@{[_dump($path_end)]}\n";
-                splice( @$path, $offset, @$path_end, @$path_end );
-            }
-        }
-        elsif( not _node_eq( $path_end->[0], $token )) {
-            if( @$path_end > 1 ) {
-                my $path_key = _re_path($self, [$path_end->[0]]);
-                my $new = {
-                    $path_key  => [ @$path_end ],
-                    $token_key => [ $token, @_ ],
-                };
-                $debug and print "#   path->node1 at $path_key/$token_key @{[_dump($new)]}\n";
-                splice( @$path, $offset, @$path_end, $new );
-            }
-            else {
-                $debug and print "#   next in path is node, trivial insert at $token_key\n";
-                $path_end->[0]{$token_key} = [$token, @_];
-                splice( @$path, $offset, @$path_end, @$path_end );
-            }
-        }
-        else {
-            while( @$path_end and _node_eq( $path_end->[0], $token )) {
-                $debug and print "#  identical nodes @{[_dump([$token])]}\n";
-                shift @$path_end;
-                $token = shift @_;
-                ++$offset;
-            }
-            if( @$path_end ) {
-                $debug and print "#   insert at $offset $token:@{[_dump(\@_)]} into @{[_dump($path_end)]}\n";
-                $path_end = $self->_insert_path( $path_end, $debug, [$token, @_] );
-                $debug and print "#   got off=$offset s=@{[scalar @_]} path_add=@{[_dump($path_end)]}\n";
-                splice( @$path, $offset, @$path - $offset, @$path_end );
-                $debug and print "#   got final=@{[_dump($path)]}\n";
-            }
-            else {
-                $token_key = _node_key($token);
-                my $new = {
-                    ''         => undef,
-                    $token_key => [ $token, @_ ],
-                };
-                $debug and print "#   convert opt @{[_dump($new)]}\n";
-                push @$path, $new;
-            }
-        }
-    }
-    else {
-        if( @$path_end ) {
-            my $new = {
-                $path_end->[0] => [ @$path_end ],
-                $token_key     => [ $token, @_ ],
-            };
-            $debug and print "#   atom->node @{[_dump($new)]}\n";
-            splice( @$path, $offset, @$path_end, $new );
-            $debug and print "#   out=@{[_dump($path)]}\n";
-        }
-        else {
-            $debug and print "#   add opt @{[_dump([$token,@_])]} via $token_key\n";
-            push @$path, {
-                ''         => undef,
-                $token_key => [ $token, @_ ],
-            };
-        }
-    }
-    $path;
+	my $self   = shift;
+	my $path   = shift;
+	my $offset = shift;
+	my $token  = shift;
+	my $debug  = shift;
+	my $path_end = [@{$path}[$offset..$#{$path}]];
+	# NB: $path->[$offset] and $[path_end->[0] are equivalent
+	my $token_key = _re_path($self, [$token]);
+	$debug and print "#  insert node(@{[_dump($token)]}:@{[_dump(\@_)]}) (key=$token_key)",
+		" at path=@{[_dump($path_end)]}\n";
+	if( ref($path_end->[0]) eq 'HASH' ) {
+		if( exists($path_end->[0]{$token_key}) ) {
+			if( @$path_end > 1 ) {
+				my $path_key = _re_path($self, [$path_end->[0]]);
+				my $new = {
+					$path_key  => [ @$path_end ],
+					$token_key => [ $token, @_ ],
+				};
+				$debug and print "#   +bifurcate new=@{[_dump($new)]}\n";
+				splice( @$path, $offset, @$path_end, $new );
+			}
+			else {
+				my $old_path = $path_end->[0]{$token_key};
+				my $new_path = [];
+				while( @$old_path and _node_eq( $old_path->[0], $token )) {
+					$debug and print "#  identical nodes in sub_path ",
+						ref($token) ? _dump($token) : $token, "\n";
+					push @$new_path, shift(@$old_path);
+					$token = shift @_;
+				}
+				if( @$new_path ) {
+					my $new;
+					my $token_key = $token;
+					if( @_ ) {
+						$new = {
+							_re_path($self, $old_path) => $old_path,
+							$token_key => [$token, @_],
+						};
+						$debug and print "#  insert_node(bifurc) n=@{[_dump([$new])]}\n";
+					}
+					else {
+						$debug and print "#  insert $token into old path @{[_dump($old_path)]}\n";
+						if( @$old_path ) {
+							$new = ($self->_insert_path( $old_path, $debug, [$token] ))->[0];
+						}
+						else {
+							$new = { '' => undef, $token => [$token] };
+						}
+					}
+					push @$new_path, $new;
+				}
+				$path_end->[0]{$token_key} = $new_path;
+				$debug and print "#   +_insert_node result=@{[_dump($path_end)]}\n";
+				splice( @$path, $offset, @$path_end, @$path_end );
+			}
+		}
+		elsif( not _node_eq( $path_end->[0], $token )) {
+			if( @$path_end > 1 ) {
+				my $path_key = _re_path($self, [$path_end->[0]]);
+				my $new = {
+					$path_key  => [ @$path_end ],
+					$token_key => [ $token, @_ ],
+				};
+				$debug and print "#   path->node1 at $path_key/$token_key @{[_dump($new)]}\n";
+				splice( @$path, $offset, @$path_end, $new );
+			}
+			else {
+				$debug and print "#   next in path is node, trivial insert at $token_key\n";
+				$path_end->[0]{$token_key} = [$token, @_];
+				splice( @$path, $offset, @$path_end, @$path_end );
+			}
+		}
+		else {
+			while( @$path_end and _node_eq( $path_end->[0], $token )) {
+				$debug and print "#  identical nodes @{[_dump([$token])]}\n";
+				shift @$path_end;
+				$token = shift @_;
+				++$offset;
+			}
+			if( @$path_end ) {
+				$debug and print "#   insert at $offset $token:@{[_dump(\@_)]} into @{[_dump($path_end)]}\n";
+				$path_end = $self->_insert_path( $path_end, $debug, [$token, @_] );
+				$debug and print "#   got off=$offset s=@{[scalar @_]} path_add=@{[_dump($path_end)]}\n";
+				splice( @$path, $offset, @$path - $offset, @$path_end );
+				$debug and print "#   got final=@{[_dump($path)]}\n";
+			}
+			else {
+				$token_key = _node_key($token);
+				my $new = {
+					''         => undef,
+					$token_key => [ $token, @_ ],
+				};
+				$debug and print "#   convert opt @{[_dump($new)]}\n";
+				push @$path, $new;
+			}
+		}
+	}
+	else {
+		if( @$path_end ) {
+			my $new = {
+				$path_end->[0] => [ @$path_end ],
+				$token_key     => [ $token, @_ ],
+			};
+			$debug and print "#   atom->node @{[_dump($new)]}\n";
+			splice( @$path, $offset, @$path_end, $new );
+			$debug and print "#   out=@{[_dump($path)]}\n";
+		}
+		else {
+			$debug and print "#   add opt @{[_dump([$token,@_])]} via $token_key\n";
+			push @$path, {
+				''         => undef,
+				$token_key => [ $token, @_ ],
+			};
+		}
+	}
+	$path;
 }
 
 sub _reduce {
-    my $self    = shift;
-    my $context = { debug => $self->_debug(DEBUG_TAIL), depth => 0 };
+	my $self    = shift;
+	my $context = { debug => $self->_debug(DEBUG_TAIL), depth => 0 };
 
-    if ($self->_debug(DEBUG_TIME)) {
-        $self->_init_time_func;
-        my $now = $self->{_time_func}->();
-        if (exists $self->{_begin_time}) {
-            printf "# load=%0.6f\n", $now - $self->{_begin_time};
-        }
-        else {
-            printf "# load-epoch=%0.6f\n", $now;
-        }
-        $self->{_begin_time} = $self->{_time_func}->();
-    }
+	if ($self->_debug(DEBUG_TIME)) {
+		$self->_init_time_func;
+		my $now = $self->{_time_func}->();
+		if (exists $self->{_begin_time}) {
+			printf "# load=%0.6f\n", $now - $self->{_begin_time};
+		}
+		else {
+			printf "# load-epoch=%0.6f\n", $now;
+		}
+		$self->{_begin_time} = $self->{_time_func}->();
+	}
 
-    my ($head, $tail) = _reduce_path( $self->_path, $context );
-    $context->{debug} and print "# final head=", _dump($head), ' tail=', _dump($tail), "\n";
-    if( !@$head ) {
-        $self->{path} = $tail;
-    }
-    else {
-        $self->{path} = [
-            @{_unrev_path( $tail, $context )},
-            @{_unrev_path( $head, $context )},
-        ];
-    }
+	my ($head, $tail) = _reduce_path( $self->_path, $context );
+	$context->{debug} and print "# final head=", _dump($head), ' tail=', _dump($tail), "\n";
+	if( !@$head ) {
+		$self->{path} = $tail;
+	}
+	else {
+		$self->{path} = [
+			@{_unrev_path( $tail, $context )},
+			@{_unrev_path( $head, $context )},
+		];
+	}
 
-    if ($self->_debug(DEBUG_TIME)) {
-        my $now = $self->{_time_func}->();
-        if (exists $self->{_begin_time}) {
-            printf "# reduce=%0.6f\n", $now - $self->{_begin_time};
-        }
-        else {
-            printf "# reduce-epoch=%0.6f\n", $now;
-        }
-        $self->{_begin_time} = $self->{_time_func}->();
-    }
+	if ($self->_debug(DEBUG_TIME)) {
+		my $now = $self->{_time_func}->();
+		if (exists $self->{_begin_time}) {
+			printf "# reduce=%0.6f\n", $now - $self->{_begin_time};
+		}
+		else {
+			printf "# reduce-epoch=%0.6f\n", $now;
+		}
+		$self->{_begin_time} = $self->{_time_func}->();
+	}
 
-    $context->{debug} and print "# final path=", _dump($self->{path}), "\n";
-    return $self;
+	$context->{debug} and print "# final path=", _dump($self->{path}), "\n";
+	return $self;
 }
 
 sub _remove_optional {
-    if( exists $_[0]->{''} ) {
-        delete $_[0]->{''};
-        return 1;
-    }
-    return 0;
+	if( exists $_[0]->{''} ) {
+		delete $_[0]->{''};
+		return 1;
+	}
+	return 0;
 }
 
 sub _reduce_path {
-    my ($path, $ctx) = @_;
-    my $indent = ' ' x $ctx->{depth};
-    my $debug  =       $ctx->{debug};
-    $debug and print "#$indent _reduce_path $ctx->{depth} ", _dump($path), "\n";
-    my $new;
-    my $head = [];
-    my $tail = [];
-    while( defined( my $p = pop @$path )) {
-        if( ref($p) eq 'HASH' ) {
-            my ($node_head, $node_tail) = _reduce_node($p, _descend($ctx) );
-            $debug and print "#$indent| head=", _dump($node_head), " tail=", _dump($node_tail), "\n";
-            push @$head, @$node_head if scalar @$node_head;
-            push @$tail, ref($node_tail) eq 'HASH' ? $node_tail : @$node_tail;
-        }
-        else {
-            if( @$head ) {
-                $debug and print "#$indent| push $p leaves @{[_dump($path)]}\n";
-                push @$tail, $p;
-            }
-            else {
-                $debug and print "#$indent| unshift $p\n";
-                unshift @$tail, $p;
-            }
-        }
-    }
-    $debug and print "#$indent| tail nr=@{[scalar @$tail]} t0=", ref($tail->[0]),
-        (ref($tail->[0]) eq 'HASH' ? " n=" . scalar(keys %{$tail->[0]}) : '' ),
-        "\n";
-    if( @$tail > 1
-        and ref($tail->[0]) eq 'HASH'
-        and keys %{$tail->[0]} == 2
-    ) {
-        my $opt;
-        my $fixed;
-        while( my ($key, $path) = each %{$tail->[0]} ) {
-            $debug and print "#$indent| scan k=$key p=@{[_dump($path)]}\n";
-            next unless $path;
-            if (@$path == 1 and ref($path->[0]) eq 'HASH') {
-                $opt = $path->[0];
-            }
-            else {
-                $fixed = $path;
-            }
-        }
-        if( exists $tail->[0]{''} ) {
-            my $path = [@{$tail}[1..$#{$tail}]];
-            $tail = $tail->[0];
-            ($head, $tail, $path) = _slide_tail( $head, $tail, $path, _descend($ctx) );
-            $tail = [$tail, @$path];
-        }
-    }
-    $debug and print "#$indent _reduce_path $ctx->{depth} out head=", _dump($head), ' tail=', _dump($tail), "\n";
-    return ($head, $tail);
+	my ($path, $ctx) = @_;
+	my $indent = ' ' x $ctx->{depth};
+	my $debug  =       $ctx->{debug};
+	$debug and print "#$indent _reduce_path $ctx->{depth} ", _dump($path), "\n";
+	my $new;
+	my $head = [];
+	my $tail = [];
+	while( defined( my $p = pop @$path )) {
+		if( ref($p) eq 'HASH' ) {
+			my ($node_head, $node_tail) = _reduce_node($p, _descend($ctx) );
+			$debug and print "#$indent| head=", _dump($node_head), " tail=", _dump($node_tail), "\n";
+			push @$head, @$node_head if scalar @$node_head;
+			push @$tail, ref($node_tail) eq 'HASH' ? $node_tail : @$node_tail;
+		}
+		else {
+			if( @$head ) {
+				$debug and print "#$indent| push $p leaves @{[_dump($path)]}\n";
+				push @$tail, $p;
+			}
+			else {
+				$debug and print "#$indent| unshift $p\n";
+				unshift @$tail, $p;
+			}
+		}
+	}
+	$debug and print "#$indent| tail nr=@{[scalar @$tail]} t0=", ref($tail->[0]),
+		(ref($tail->[0]) eq 'HASH' ? " n=" . scalar(keys %{$tail->[0]}) : '' ),
+		"\n";
+	if( @$tail > 1
+		and ref($tail->[0]) eq 'HASH'
+		and keys %{$tail->[0]} == 2
+	) {
+		my $opt;
+		my $fixed;
+		while( my ($key, $path) = each %{$tail->[0]} ) {
+			$debug and print "#$indent| scan k=$key p=@{[_dump($path)]}\n";
+			next unless $path;
+			if (@$path == 1 and ref($path->[0]) eq 'HASH') {
+				$opt = $path->[0];
+			}
+			else {
+				$fixed = $path;
+			}
+		}
+		if( exists $tail->[0]{''} ) {
+			my $path = [@{$tail}[1..$#{$tail}]];
+			$tail = $tail->[0];
+			($head, $tail, $path) = _slide_tail( $head, $tail, $path, _descend($ctx) );
+			$tail = [$tail, @$path];
+		}
+	}
+	$debug and print "#$indent _reduce_path $ctx->{depth} out head=", _dump($head), ' tail=', _dump($tail), "\n";
+	return ($head, $tail);
 }
 
 sub _reduce_node {
-    my ($node, $ctx) = @_;
-    my $indent = ' ' x $ctx->{depth};
-    my $debug  =       $ctx->{debug};
-    my $optional = _remove_optional($node);
-    $debug and print "#$indent _reduce_node $ctx->{depth} in @{[_dump($node)]} opt=$optional\n";
-    if( $optional and scalar keys %$node == 1 ) {
-        my $path = (values %$node)[0];
-        if( not grep { ref($_) eq 'HASH' } @$path ) {
-            # if we have removed an optional, and there is only one path
-            # left then there is nothing left to compare. Because of the
-            # optional it cannot participate in any further reductions.
-            # (unless we test for equality among sub-trees).
-            my $result = {
-                ''         => undef,
-                $path->[0] => $path
-            };
-            $debug and print "#$indent| fast fail @{[_dump($result)]}\n";
-            return [], $result;
-        }
-    }
+	my ($node, $ctx) = @_;
+	my $indent = ' ' x $ctx->{depth};
+	my $debug  =       $ctx->{debug};
+	my $optional = _remove_optional($node);
+	$debug and print "#$indent _reduce_node $ctx->{depth} in @{[_dump($node)]} opt=$optional\n";
+	if( $optional and scalar keys %$node == 1 ) {
+		my $path = (values %$node)[0];
+		if( not grep { ref($_) eq 'HASH' } @$path ) {
+			# if we have removed an optional, and there is only one path
+			# left then there is nothing left to compare. Because of the
+			# optional it cannot participate in any further reductions.
+			# (unless we test for equality among sub-trees).
+			my $result = {
+				''         => undef,
+				$path->[0] => $path
+			};
+			$debug and print "#$indent| fast fail @{[_dump($result)]}\n";
+			return [], $result;
+		}
+	}
 
-    my( $fail, $reduce ) = _scan_node( $node, _descend($ctx) );
+	my( $fail, $reduce ) = _scan_node( $node, _descend($ctx) );
 
-    $debug and print "#$indent|_scan_node done opt=$optional reduce=@{[_dump($reduce)]} fail=@{[_dump($fail)]}\n";
+	$debug and print "#$indent|_scan_node done opt=$optional reduce=@{[_dump($reduce)]} fail=@{[_dump($fail)]}\n";
 
-    # We now perform tail reduction on each of the nodes in the reduce
-    # hash. If we have only one key, we know we will have a successful
-    # reduction (since everything that was inserted into the node based
-    # on the value of the last token of each path all mapped to the same
-    # value).
+	# We now perform tail reduction on each of the nodes in the reduce
+	# hash. If we have only one key, we know we will have a successful
+	# reduction (since everything that was inserted into the node based
+	# on the value of the last token of each path all mapped to the same
+	# value).
 
-    if( @$fail == 0 and keys %$reduce == 1 and not $optional) {
-        # every path shares a common path
-        my $path = (values %$reduce)[0];
-        my ($common, $tail) = _do_reduce( $path, _descend($ctx) );
-        $debug and print "#$indent|_reduce_node  $ctx->{depth} common=@{[_dump($common)]} tail=", _dump($tail), "\n";
-        return( $common, $tail );
-    }
+	if( @$fail == 0 and keys %$reduce == 1 and not $optional) {
+		# every path shares a common path
+		my $path = (values %$reduce)[0];
+		my ($common, $tail) = _do_reduce( $path, _descend($ctx) );
+		$debug and print "#$indent|_reduce_node  $ctx->{depth} common=@{[_dump($common)]} tail=", _dump($tail), "\n";
+		return( $common, $tail );
+	}
 
-    # this node resulted in a list of paths, game over
-    $ctx->{indent} = $indent;
-    return _reduce_fail( $reduce, $fail, $optional, _descend($ctx) );
+	# this node resulted in a list of paths, game over
+	$ctx->{indent} = $indent;
+	return _reduce_fail( $reduce, $fail, $optional, _descend($ctx) );
 }
 
 sub _reduce_fail {
-    my( $reduce, $fail, $optional, $ctx ) = @_;
-    my( $debug, $depth, $indent ) = @{$ctx}{qw(debug depth indent)};
-    my %result;
-    $result{''} = undef if $optional;
-    my $p;
-    for $p (keys %$reduce) {
-        my $path = $reduce->{$p};
-        if( scalar @$path == 1 ) {
-            $path = $path->[0];
-            $debug and print "#$indent| -simple opt=$optional unrev @{[_dump($path)]}\n";
-            $path = _unrev_path($path, _descend($ctx) );
-            $result{_node_key($path->[0])} = $path;
-        }
-        else {
-            $debug and print "#$indent| _do_reduce(@{[_dump($path)]})\n";
-            my ($common, $tail) = _do_reduce( $path, _descend($ctx) );
-            $path = [
-                (
-                    ref($tail) eq 'HASH'
-                        ? _unrev_node($tail, _descend($ctx) )
-                        : _unrev_path($tail, _descend($ctx) )
-                ),
-                @{_unrev_path($common, _descend($ctx) )}
-            ];
-            $debug and print "#$indent| +reduced @{[_dump($path)]}\n";
-            $result{_node_key($path->[0])} = $path;
-        }
-    }
-    my $f;
-    for $f( @$fail ) {
-        $debug and print "#$indent| +fail @{[_dump($f)]}\n";
-        $result{$f->[0]} = $f;
-    }
-    $debug and print "#$indent _reduce_fail $depth fail=@{[_dump(\%result)]}\n";
-    return ( [], \%result );
+	my( $reduce, $fail, $optional, $ctx ) = @_;
+	my( $debug, $depth, $indent ) = @{$ctx}{qw(debug depth indent)};
+	my %result;
+	$result{''} = undef if $optional;
+	my $p;
+	for $p (keys %$reduce) {
+		my $path = $reduce->{$p};
+		if( scalar @$path == 1 ) {
+			$path = $path->[0];
+			$debug and print "#$indent| -simple opt=$optional unrev @{[_dump($path)]}\n";
+			$path = _unrev_path($path, _descend($ctx) );
+			$result{_node_key($path->[0])} = $path;
+		}
+		else {
+			$debug and print "#$indent| _do_reduce(@{[_dump($path)]})\n";
+			my ($common, $tail) = _do_reduce( $path, _descend($ctx) );
+			$path = [
+				(
+					ref($tail) eq 'HASH'
+						? _unrev_node($tail, _descend($ctx) )
+						: _unrev_path($tail, _descend($ctx) )
+				),
+				@{_unrev_path($common, _descend($ctx) )}
+			];
+			$debug and print "#$indent| +reduced @{[_dump($path)]}\n";
+			$result{_node_key($path->[0])} = $path;
+		}
+	}
+	my $f;
+	for $f( @$fail ) {
+		$debug and print "#$indent| +fail @{[_dump($f)]}\n";
+		$result{$f->[0]} = $f;
+	}
+	$debug and print "#$indent _reduce_fail $depth fail=@{[_dump(\%result)]}\n";
+	return ( [], \%result );
 }
 
 sub _scan_node {
-    my( $node, $ctx ) = @_;
-    my $indent = ' ' x $ctx->{depth};
-    my $debug  =       $ctx->{debug};
+	my( $node, $ctx ) = @_;
+	my $indent = ' ' x $ctx->{depth};
+	my $debug  =       $ctx->{debug};
 
-    # For all the paths in the node, reverse them. If the first token
-    # of the path is a scalar, push it onto an array in a hash keyed by
-    # the value of the scalar.
-    #
-    # If it is a node, call _reduce_node on this node beforehand. If we
-    # get back a common head, all of the paths in the subnode shared a
-    # common tail. We then store the common part and the remaining node
-    # of paths (which is where the paths diverged from the end and install
-    # this into the same hash. At this point both the common and the tail
-    # are in reverse order, just as simple scalar paths are.
-    #
-    # On the other hand, if there were no common path returned then all
-    # the paths of the sub-node diverge at the end character. In this
-    # case the tail cannot participate in any further reductions and will
-    # appear in forward order.
-    #
-    # certainly the hurgliest function in the whole file :(
+	# For all the paths in the node, reverse them. If the first token
+	# of the path is a scalar, push it onto an array in a hash keyed by
+	# the value of the scalar.
+	#
+	# If it is a node, call _reduce_node on this node beforehand. If we
+	# get back a common head, all of the paths in the subnode shared a
+	# common tail. We then store the common part and the remaining node
+	# of paths (which is where the paths diverged from the end and install
+	# this into the same hash. At this point both the common and the tail
+	# are in reverse order, just as simple scalar paths are.
+	#
+	# On the other hand, if there were no common path returned then all
+	# the paths of the sub-node diverge at the end character. In this
+	# case the tail cannot participate in any further reductions and will
+	# appear in forward order.
+	#
+	# certainly the hurgliest function in the whole file :(
 
-    # $debug = 1 if $depth >= 8;
-    my @fail;
-    my %reduce;
+	# $debug = 1 if $depth >= 8;
+	my @fail;
+	my %reduce;
 
-    my $n;
-    for $n(
-        map { substr($_, index($_, '#')+1) }
-        sort
-        map {
-            join( '|' =>
-                scalar(grep {ref($_) eq 'HASH'} @{$node->{$_}}),
-                _node_offset($node->{$_}),
-                scalar @{$node->{$_}},
-            )
-            . "#$_"
-        }
-    keys %$node ) {
-        my( $end, @path ) = reverse @{$node->{$n}};
-        if( ref($end) ne 'HASH' ) {
-            $debug and print "# $indent|_scan_node push reduce ($end:@{[_dump(\@path)]})\n";
-            push @{$reduce{$end}}, [ $end, @path ];
-        }
-        else {
-            $debug and print "# $indent|_scan_node head=", _dump(\@path), ' tail=', _dump($end), "\n";
-            my $new_path;
-            # deal with sing, singing => s(?:ing)?ing
-            if( keys %$end == 2 and exists $end->{''} ) {
-                my ($key, $opt_path) = each %$end;
-                ($key, $opt_path) = each %$end if $key eq '';
-                $opt_path = [reverse @{$opt_path}];
-                $debug and print "# $indent| check=", _dump($opt_path), "\n";
-                my $end = { '' => undef, $opt_path->[0] => [@$opt_path] };
-                my $head = [];
-                my $path = [@path];
-                ($head, my $slide, $path) = _slide_tail( $head, $end, $path, $ctx );
-                if( @$head ) {
-                    $new_path = [ @$head, $slide, @$path ];
-                }
-            }
-            if( $new_path ) {
-                $debug and print "# $indent|_scan_node slid=", _dump($new_path), "\n";
-                push @{$reduce{$new_path->[0]}}, $new_path;
-            }
-            else {
-                my( $common, $tail ) = _reduce_node( $end, _descend($ctx) );
-                    if( not @$common ) {
-                    $debug and print "# $indent| +failed $n\n";
-                    push @fail, [reverse(@path), $tail];
-                }
-                else {
-                    my $path = [@path];
-                    $debug and print "# $indent|_scan_node ++recovered common=@{[_dump($common)]} tail=",
-                        _dump($tail), " path=@{[_dump($path)]}\n";
-                    if( ref($tail) eq 'HASH'
-                        and keys %$tail == 2
-                    ) {
-                        if( exists $tail->{''} ) {
-                            ($common, $tail, $path) = _slide_tail( $common, $tail, $path, $ctx );
-                        }
-                    }
-                    push @{$reduce{$common->[0]}}, [
-                        @$common,
-                        (ref($tail) eq 'HASH' ? $tail : @$tail ),
-                        @$path
-                    ];
-                }
-            }
-        }
-    }
-    $debug and print
-        "# $indent|_scan_node counts: reduce=@{[scalar keys %reduce]} fail=@{[scalar @fail]}\n";
-    return( \@fail, \%reduce );
+	my $n;
+	for $n(
+		map { substr($_, index($_, '#')+1) }
+		sort
+		map {
+			join( '|' =>
+				scalar(grep {ref($_) eq 'HASH'} @{$node->{$_}}),
+				_node_offset($node->{$_}),
+				scalar @{$node->{$_}},
+			)
+			. "#$_"
+		}
+	keys %$node ) {
+		my( $end, @path ) = reverse @{$node->{$n}};
+		if( ref($end) ne 'HASH' ) {
+			$debug and print "# $indent|_scan_node push reduce ($end:@{[_dump(\@path)]})\n";
+			push @{$reduce{$end}}, [ $end, @path ];
+		}
+		else {
+			$debug and print "# $indent|_scan_node head=", _dump(\@path), ' tail=', _dump($end), "\n";
+			my $new_path;
+			# deal with sing, singing => s(?:ing)?ing
+			if( keys %$end == 2 and exists $end->{''} ) {
+				my ($key, $opt_path) = each %$end;
+				($key, $opt_path) = each %$end if $key eq '';
+				$opt_path = [reverse @{$opt_path}];
+				$debug and print "# $indent| check=", _dump($opt_path), "\n";
+				my $end = { '' => undef, $opt_path->[0] => [@$opt_path] };
+				my $head = [];
+				my $path = [@path];
+				($head, my $slide, $path) = _slide_tail( $head, $end, $path, $ctx );
+				if( @$head ) {
+					$new_path = [ @$head, $slide, @$path ];
+				}
+			}
+			if( $new_path ) {
+				$debug and print "# $indent|_scan_node slid=", _dump($new_path), "\n";
+				push @{$reduce{$new_path->[0]}}, $new_path;
+			}
+			else {
+				my( $common, $tail ) = _reduce_node( $end, _descend($ctx) );
+					if( not @$common ) {
+					$debug and print "# $indent| +failed $n\n";
+					push @fail, [reverse(@path), $tail];
+				}
+				else {
+					my $path = [@path];
+					$debug and print "# $indent|_scan_node ++recovered common=@{[_dump($common)]} tail=",
+						_dump($tail), " path=@{[_dump($path)]}\n";
+					if( ref($tail) eq 'HASH'
+						and keys %$tail == 2
+					) {
+						if( exists $tail->{''} ) {
+							($common, $tail, $path) = _slide_tail( $common, $tail, $path, $ctx );
+						}
+					}
+					push @{$reduce{$common->[0]}}, [
+						@$common,
+						(ref($tail) eq 'HASH' ? $tail : @$tail ),
+						@$path
+					];
+				}
+			}
+		}
+	}
+	$debug and print
+		"# $indent|_scan_node counts: reduce=@{[scalar keys %reduce]} fail=@{[scalar @fail]}\n";
+	return( \@fail, \%reduce );
 }
 
 sub _do_reduce {
-    my ($path, $ctx) = @_;
-    my $indent = ' ' x $ctx->{depth};
-    my $debug  =       $ctx->{debug};
-    my $ra = Regexp::Assemble->new(chomp=>0);
-    $ra->debug($debug);
-    $debug and print "# $indent| do @{[_dump($path)]}\n";
-    $ra->_insertr( $_ ) for
-        # When nodes come into the picture, we have to be careful
-        # about how we insert the paths into the assembly.
-        # Paths with nodes first, then closest node to front
-        # then shortest path. Merely because if we can control
-        # order in which paths containing nodes get inserted,
-        # then we can make a couple of assumptions that simplify
-        # the code in _insert_node.
-        sort {
-            scalar(grep {ref($_) eq 'HASH'} @$a)
-            <=> scalar(grep {ref($_) eq 'HASH'} @$b)
-                ||
-            _node_offset($b) <=> _node_offset($a)
-                ||
-            scalar @$a <=> scalar @$b
-        }
-        @$path
-    ;
-    $path = $ra->_path;
-    my $common = [];
-    push @$common, shift @$path while( ref($path->[0]) ne 'HASH' );
-    my $tail = scalar( @$path ) > 1 ? [@$path] : $path->[0];
-    $debug and print "# $indent| _do_reduce common=@{[_dump($common)]} tail=@{[_dump($tail)]}\n";
-    return ($common, $tail);
+	my ($path, $ctx) = @_;
+	my $indent = ' ' x $ctx->{depth};
+	my $debug  =       $ctx->{debug};
+	my $ra = Regexp::Assemble->new(chomp=>0);
+	$ra->debug($debug);
+	$debug and print "# $indent| do @{[_dump($path)]}\n";
+	$ra->_insertr( $_ ) for
+		# When nodes come into the picture, we have to be careful
+		# about how we insert the paths into the assembly.
+		# Paths with nodes first, then closest node to front
+		# then shortest path. Merely because if we can control
+		# order in which paths containing nodes get inserted,
+		# then we can make a couple of assumptions that simplify
+		# the code in _insert_node.
+		sort {
+			scalar(grep {ref($_) eq 'HASH'} @$a)
+			<=> scalar(grep {ref($_) eq 'HASH'} @$b)
+				||
+			_node_offset($b) <=> _node_offset($a)
+				||
+			scalar @$a <=> scalar @$b
+		}
+		@$path
+	;
+	$path = $ra->_path;
+	my $common = [];
+	push @$common, shift @$path while( ref($path->[0]) ne 'HASH' );
+	my $tail = scalar( @$path ) > 1 ? [@$path] : $path->[0];
+	$debug and print "# $indent| _do_reduce common=@{[_dump($common)]} tail=@{[_dump($tail)]}\n";
+	return ($common, $tail);
 }
 
 sub _node_offset {
-    # return the offset that the first node is found, or -ve
-    # optimised for speed
-    my $nr = @{$_[0]};
-    my $atom = -1;
-    ref($_[0]->[$atom]) eq 'HASH' and return $atom while ++$atom < $nr;
-    return -1;
+	# return the offset that the first node is found, or -ve
+	# optimised for speed
+	my $nr = @{$_[0]};
+	my $atom = -1;
+	ref($_[0]->[$atom]) eq 'HASH' and return $atom while ++$atom < $nr;
+	return -1;
 }
 
 sub _slide_tail {
-    my $head   = shift;
-    my $tail   = shift;
-    my $path   = shift;
-    my $ctx    = shift;
-    my $indent = ' ' x $ctx->{depth};
-    my $debug  =       $ctx->{debug};
-    $debug and print "# $indent| slide in h=", _dump($head),
-        ' t=', _dump($tail), ' p=', _dump($path), "\n";
-    my $slide_path = (each %$tail)[-1];
-    $slide_path = (each %$tail)[-1] unless defined $slide_path;
-    $debug and print "# $indent| slide potential ", _dump($slide_path), " over ", _dump($path), "\n";
-    while( defined $path->[0] and $path->[0] eq $slide_path->[0] ) {
-        $debug and print "# $indent| slide=tail=$slide_path->[0]\n";
-        my $slide = shift @$path;
-        shift @$slide_path;
-        push @$slide_path, $slide;
-        push @$head, $slide;
-    }
-    $debug and print "# $indent| slide path ", _dump($slide_path), "\n";
-    my $slide_node = {
-        '' => undef,
-        _node_key($slide_path->[0]) => $slide_path,
-    };
-    $debug and print "# $indent| slide out h=", _dump($head),
-        ' s=', _dump($slide_node), ' p=', _dump($path), "\n";
-    return ($head, $slide_node, $path);
+	my $head   = shift;
+	my $tail   = shift;
+	my $path   = shift;
+	my $ctx    = shift;
+	my $indent = ' ' x $ctx->{depth};
+	my $debug  =       $ctx->{debug};
+	$debug and print "# $indent| slide in h=", _dump($head),
+		' t=', _dump($tail), ' p=', _dump($path), "\n";
+	my $slide_path = (each %$tail)[-1];
+	$slide_path = (each %$tail)[-1] unless defined $slide_path;
+	$debug and print "# $indent| slide potential ", _dump($slide_path), " over ", _dump($path), "\n";
+	while( defined $path->[0] and $path->[0] eq $slide_path->[0] ) {
+		$debug and print "# $indent| slide=tail=$slide_path->[0]\n";
+		my $slide = shift @$path;
+		shift @$slide_path;
+		push @$slide_path, $slide;
+		push @$head, $slide;
+	}
+	$debug and print "# $indent| slide path ", _dump($slide_path), "\n";
+	my $slide_node = {
+		'' => undef,
+		_node_key($slide_path->[0]) => $slide_path,
+	};
+	$debug and print "# $indent| slide out h=", _dump($head),
+		' s=', _dump($slide_node), ' p=', _dump($path), "\n";
+	return ($head, $slide_node, $path);
 }
 
 sub _unrev_path {
-    my ($path, $ctx) = @_;
-    my $indent = ' ' x $ctx->{depth};
-    my $debug  =       $ctx->{debug};
-    my $new;
-    if( not grep { ref($_) } @$path ) {
-        $debug and print "# ${indent}_unrev path fast ", _dump($path);
-        $new = [reverse @$path];
-        $debug and print "#  -> ", _dump($new), "\n";
-        return $new;
-    }
-    $debug and print "# ${indent}unrev path in ", _dump($path), "\n";
-    while( defined( my $p = pop @$path )) {
-        push @$new,
-              ref($p) eq 'HASH'  ? _unrev_node($p, _descend($ctx) )
-            : ref($p) eq 'ARRAY' ? _unrev_path($p, _descend($ctx) )
-            : $p
-        ;
-    }
-    $debug and print "# ${indent}unrev path out ", _dump($new), "\n";
-    return $new;
+	my ($path, $ctx) = @_;
+	my $indent = ' ' x $ctx->{depth};
+	my $debug  =       $ctx->{debug};
+	my $new;
+	if( not grep { ref($_) } @$path ) {
+		$debug and print "# ${indent}_unrev path fast ", _dump($path);
+		$new = [reverse @$path];
+		$debug and print "#  -> ", _dump($new), "\n";
+		return $new;
+	}
+	$debug and print "# ${indent}unrev path in ", _dump($path), "\n";
+	while( defined( my $p = pop @$path )) {
+		push @$new,
+			  ref($p) eq 'HASH'  ? _unrev_node($p, _descend($ctx) )
+			: ref($p) eq 'ARRAY' ? _unrev_path($p, _descend($ctx) )
+			: $p
+		;
+	}
+	$debug and print "# ${indent}unrev path out ", _dump($new), "\n";
+	return $new;
 }
 
 sub _unrev_node {
-    my ($node, $ctx ) = @_;
-    my $indent = ' ' x $ctx->{depth};
-    my $debug  =       $ctx->{debug};
-    my $optional = _remove_optional($node);
-    $debug and print "# ${indent}unrev node in ", _dump($node), " opt=$optional\n";
-    my $new;
-    $new->{''} = undef if $optional;
-    my $n;
-    for $n( keys %$node ) {
-        my $path = _unrev_path($node->{$n}, _descend($ctx) );
-        $new->{_node_key($path->[0])} = $path;
-    }
-    $debug and print "# ${indent}unrev node out ", _dump($new), "\n";
-    return $new;
+	my ($node, $ctx ) = @_;
+	my $indent = ' ' x $ctx->{depth};
+	my $debug  =       $ctx->{debug};
+	my $optional = _remove_optional($node);
+	$debug and print "# ${indent}unrev node in ", _dump($node), " opt=$optional\n";
+	my $new;
+	$new->{''} = undef if $optional;
+	my $n;
+	for $n( keys %$node ) {
+		my $path = _unrev_path($node->{$n}, _descend($ctx) );
+		$new->{_node_key($path->[0])} = $path;
+	}
+	$debug and print "# ${indent}unrev node out ", _dump($new), "\n";
+	return $new;
 }
 
 sub _node_key {
-    my $node = shift;
-    return _node_key($node->[0]) if ref($node) eq 'ARRAY';
-    return $node unless ref($node) eq 'HASH';
-    my $key = '';
-    my $k;
-    for $k( keys %$node ) {
-        next if $k eq '';
-        $key = $k if $key eq '' or $key gt $k;
-    }
-    return $key;
+	my $node = shift;
+	return _node_key($node->[0]) if ref($node) eq 'ARRAY';
+	return $node unless ref($node) eq 'HASH';
+	my $key = '';
+	my $k;
+	for $k( keys %$node ) {
+		next if $k eq '';
+		$key = $k if $key eq '' or $key gt $k;
+	}
+	return $key;
 }
 
 sub _descend {
-    # Take a context object, and increase the depth by one.
-    # By creating a fresh hash each time, we don't have to
-    # bother adding make-work code to decrease the depth
-    # when we return from what we called.
-    my $ctx = shift;
-    return {%$ctx, depth => $ctx->{depth}+1};
+	# Take a context object, and increase the depth by one.
+	# By creating a fresh hash each time, we don't have to
+	# bother adding make-work code to decrease the depth
+	# when we return from what we called.
+	my $ctx = shift;
+	return {%$ctx, depth => $ctx->{depth}+1};
 }
 
 #####################################################################
 
 sub _make_class {
-    my $self = shift;
-    my %set = map { ($_,1) } @_;
-    delete $set{'\\d'} if exists $set{'\\w'};
-    delete $set{'\\D'} if exists $set{'\\W'};
-    return '.' if exists $set{'.'}
-        or ($self->{fold_meta_pairs} and (
-               (exists $set{'\\d'} and exists $set{'\\D'})
-            or (exists $set{'\\s'} and exists $set{'\\S'})
-            or (exists $set{'\\w'} and exists $set{'\\W'})
-        ))
-    ;
-    for my $meta( q/\\d/, q/\\D/, q/\\s/, q/\\S/, q/\\w/, q/\\W/ ) {
-        if( exists $set{$meta} ) {
-            my $re = qr/$meta/;
-            my @delete;
-            $_ =~ /^$re$/ and push @delete, $_ for keys %set;
-            delete @set{@delete} if @delete;
-        }
-    }
-    return (keys %set)[0] if keys %set == 1;
-    for my $meta( '.', '+', '*', '?', '(', ')', '^', '@', '$', '[', '/', ) {
-        exists $set{"\\$meta"} and $set{$meta} = delete $set{"\\$meta"};
-    }
-    my $dash  = exists $set{'-'} ? do { delete($set{'-'}), '-' } : '';
-    my $caret = exists $set{'^'} ? do { delete($set{'^'}), '^' } : '';
-    my $class = join( '' => sort keys %set );
-    $class =~ s/0123456789/\\d/ and $class eq '\\d' and return $class;
-    return "[$dash$class$caret]";
+	my $self = shift;
+	my %set = map { ($_,1) } @_;
+	delete $set{'\\d'} if exists $set{'\\w'};
+	delete $set{'\\D'} if exists $set{'\\W'};
+	return '.' if exists $set{'.'}
+		or ($self->{fold_meta_pairs} and (
+			   (exists $set{'\\d'} and exists $set{'\\D'})
+			or (exists $set{'\\s'} and exists $set{'\\S'})
+			or (exists $set{'\\w'} and exists $set{'\\W'})
+		))
+	;
+	for my $meta( q/\\d/, q/\\D/, q/\\s/, q/\\S/, q/\\w/, q/\\W/ ) {
+		if( exists $set{$meta} ) {
+			my $re = qr/$meta/;
+			my @delete;
+			$_ =~ /^$re$/ and push @delete, $_ for keys %set;
+			delete @set{@delete} if @delete;
+		}
+	}
+	return (keys %set)[0] if keys %set == 1;
+	for my $meta( '.', '+', '*', '?', '(', ')', '^', '@', '$', '[', '/', ) {
+		exists $set{"\\$meta"} and $set{$meta} = delete $set{"\\$meta"};
+	}
+	my $dash  = exists $set{'-'} ? do { delete($set{'-'}), '-' } : '';
+	my $caret = exists $set{'^'} ? do { delete($set{'^'}), '^' } : '';
+	my $class = join( '' => sort keys %set );
+	$class =~ s/0123456789/\\d/ and $class eq '\\d' and return $class;
+	return "[$dash$class$caret]";
 }
 
 sub _re_sort {
-    return length $b <=> length $a || $a cmp $b
+	return length $b <=> length $a || $a cmp $b
 }
 
 sub _combine {
-    my $self = shift;
-    my $type = shift;
-    # print "c in = @{[_dump(\@_)]}\n";
-    # my $combine =
-    return '('
-    . $type
-    . do {
-        my( @short, @long );
-        push @{ /^$Single_Char$/ ? \@short : \@long}, $_ for @_;
-        if( @short == 1 ) {
-            @long = sort _re_sort @long, @short;
-        }
-        elsif( @short > 1 ) {
-            # yucky but true
-            my @combine = (_make_class($self, @short), sort _re_sort @long);
-            @long = @combine;
-        }
-        else {
-            @long = sort _re_sort @long;
-        }
-        join( '|', @long );
-    }
-    . ')';
-    # print "combine <$combine>\n";
-    # $combine;
+	my $self = shift;
+	my $type = shift;
+	# print "c in = @{[_dump(\@_)]}\n";
+	# my $combine =
+	return '('
+	. $type
+	. do {
+		my( @short, @long );
+		push @{ /^$Single_Char$/ ? \@short : \@long}, $_ for @_;
+		if( @short == 1 ) {
+			@long = sort _re_sort @long, @short;
+		}
+		elsif( @short > 1 ) {
+			# yucky but true
+			my @combine = (_make_class($self, @short), sort _re_sort @long);
+			@long = @combine;
+		}
+		else {
+			@long = sort _re_sort @long;
+		}
+		join( '|', @long );
+	}
+	. ')';
+	# print "combine <$combine>\n";
+	# $combine;
 }
 
 sub _combine_new {
-    my $self = shift;
-    my( @short, @long );
-    push @{ /^$Single_Char$/ ? \@short : \@long}, $_ for @_;
-    if( @short == 1 and @long == 0 ) {
-        return $short[0];
-    }
-    elsif( @short > 1 and @short == @_ ) {
-        return _make_class($self, @short);
-    }
-    else {
-        return '(?:'
-            . join( '|' =>
-                @short > 1
-                    ? ( _make_class($self, @short), sort _re_sort @long)
-                    : ( (sort _re_sort( @long )), @short )
-            )
-        . ')';
-    }
+	my $self = shift;
+	my( @short, @long );
+	push @{ /^$Single_Char$/ ? \@short : \@long}, $_ for @_;
+	if( @short == 1 and @long == 0 ) {
+		return $short[0];
+	}
+	elsif( @short > 1 and @short == @_ ) {
+		return _make_class($self, @short);
+	}
+	else {
+		return '(?:'
+			. join( '|' =>
+				@short > 1
+					? ( _make_class($self, @short), sort _re_sort @long)
+					: ( (sort _re_sort( @long )), @short )
+			)
+		. ')';
+	}
 }
 
 sub _re_path {
-    my $self = shift;
-    # in shorter assemblies, _re_path() is the second hottest
-    # routine. after insert(), so make it fast.
+	my $self = shift;
+	# in shorter assemblies, _re_path() is the second hottest
+	# routine. after insert(), so make it fast.
 
-    if ($self->{unroll_plus}) {
-        # but we can't easily make this blockless
-        my @arr = @{$_[0]};
-        my $str = '';
-        my $skip = 0;
-        for my $i (0..$#arr) {
-            if (ref($arr[$i]) eq 'ARRAY') {
-                $str .= _re_path($self, $arr[$i]);
-            }
-            elsif (ref($arr[$i]) eq 'HASH') {
-                $str .= exists $arr[$i]->{''}
-                    ? _combine_new( $self,
-                        map { _re_path( $self, $arr[$i]->{$_} ) } grep { $_ ne '' } keys %{$arr[$i]}
-                    ) . '?'
-                    : _combine_new($self, map { _re_path( $self, $arr[$i]->{$_} ) } keys %{$arr[$i]})
-                ;
-            }
-            elsif ($i < $#arr and $arr[$i+1] =~ /\A$arr[$i]\*(\??)\Z/) {
-                $str .= "$arr[$i]+" . (defined $1 ? $1 : '');
-                ++$skip;
-            }
-            elsif ($skip) {
-                $skip = 0;
-            }
-            else {
-                $str .= $arr[$i];
-            }
-        }
-        return $str;
-    }
+	if ($self->{unroll_plus}) {
+		# but we can't easily make this blockless
+		my @arr = @{$_[0]};
+		my $str = '';
+		my $skip = 0;
+		for my $i (0..$#arr) {
+			if (ref($arr[$i]) eq 'ARRAY') {
+				$str .= _re_path($self, $arr[$i]);
+			}
+			elsif (ref($arr[$i]) eq 'HASH') {
+				$str .= exists $arr[$i]->{''}
+					? _combine_new( $self,
+						map { _re_path( $self, $arr[$i]->{$_} ) } grep { $_ ne '' } keys %{$arr[$i]}
+					) . '?'
+					: _combine_new($self, map { _re_path( $self, $arr[$i]->{$_} ) } keys %{$arr[$i]})
+				;
+			}
+			elsif ($i < $#arr and $arr[$i+1] =~ /\A$arr[$i]\*(\??)\Z/) {
+				$str .= "$arr[$i]+" . (defined $1 ? $1 : '');
+				++$skip;
+			}
+			elsif ($skip) {
+				$skip = 0;
+			}
+			else {
+				$str .= $arr[$i];
+			}
+		}
+		return $str;
+	}
 
-    return join( '', @_ ) unless grep { length ref $_ } @_;
-    my $p;
-    return join '', map {
-        ref($_) eq '' ? $_
-        : ref($_) eq 'HASH' ? do {
-            # In the case of a node, see whether there's a '' which
-            # indicates that the whole thing is optional and thus
-            # requires a trailing ?
-            # Unroll the two different paths to avoid the needless
-            # grep when it isn't necessary.
-            $p = $_;
-            exists $_->{''}
-            ?  _combine_new( $self,
-                map { _re_path( $self, $p->{$_} ) } grep { $_ ne '' } keys %$_
-            ) . '?'
-            : _combine_new($self, map { _re_path( $self, $p->{$_} ) } keys %$_ )
-        }
-        : _re_path($self, $_) # ref($_) eq 'ARRAY'
-    } @{$_[0]}
+	return join( '', @_ ) unless grep { length ref $_ } @_;
+	my $p;
+	return join '', map {
+		ref($_) eq '' ? $_
+		: ref($_) eq 'HASH' ? do {
+			# In the case of a node, see whether there's a '' which
+			# indicates that the whole thing is optional and thus
+			# requires a trailing ?
+			# Unroll the two different paths to avoid the needless
+			# grep when it isn't necessary.
+			$p = $_;
+			exists $_->{''}
+			?  _combine_new( $self,
+				map { _re_path( $self, $p->{$_} ) } grep { $_ ne '' } keys %$_
+			) . '?'
+			: _combine_new($self, map { _re_path( $self, $p->{$_} ) } keys %$_ )
+		}
+		: _re_path($self, $_) # ref($_) eq 'ARRAY'
+	} @{$_[0]}
 }
 
 sub _lookahead {
-    my $in = shift;
-    my %head;
-    my $path;
-    for $path( keys %$in ) {
-        next unless defined $in->{$path};
-        # print "look $path: ", ref($in->{$path}[0]), ".\n";
-        if( ref($in->{$path}[0]) eq 'HASH' ) {
-            my $next = 0;
-            while( ref($in->{$path}[$next]) eq 'HASH' and @{$in->{$path}} > $next + 1 ) {
-                if( exists $in->{$path}[$next]{''} ) {
-                    ++$head{$in->{$path}[$next+1]};
-                }
-                ++$next;
-            }
-            my $inner = _lookahead( $in->{$path}[0] );
-            @head{ keys %$inner } = (values %$inner);
-        }
-        elsif( ref($in->{$path}[0]) eq 'ARRAY' ) {
-            my $subpath = $in->{$path}[0];
-            for( my $sp = 0; $sp < @$subpath; ++$sp ) {
-                if( ref($subpath->[$sp]) eq 'HASH' ) {
-                    my $follow = _lookahead( $subpath->[$sp] );
-                    @head{ keys %$follow } = (values %$follow);
-                    last unless exists $subpath->[$sp]{''};
-                }
-                else {
-                    ++$head{$subpath->[$sp]};
-                    last;
-                }
-            }
-        }
-        else {
-            ++$head{ $in->{$path}[0] };
-        }
-    }
-    # print "_lookahead ", _dump($in), '==>', _dump([keys %head]), "\n";
-    return \%head;
+	my $in = shift;
+	my %head;
+	my $path;
+	for $path( keys %$in ) {
+		next unless defined $in->{$path};
+		# print "look $path: ", ref($in->{$path}[0]), ".\n";
+		if( ref($in->{$path}[0]) eq 'HASH' ) {
+			my $next = 0;
+			while( ref($in->{$path}[$next]) eq 'HASH' and @{$in->{$path}} > $next + 1 ) {
+				if( exists $in->{$path}[$next]{''} ) {
+					++$head{$in->{$path}[$next+1]};
+				}
+				++$next;
+			}
+			my $inner = _lookahead( $in->{$path}[0] );
+			@head{ keys %$inner } = (values %$inner);
+		}
+		elsif( ref($in->{$path}[0]) eq 'ARRAY' ) {
+			my $subpath = $in->{$path}[0];
+			for( my $sp = 0; $sp < @$subpath; ++$sp ) {
+				if( ref($subpath->[$sp]) eq 'HASH' ) {
+					my $follow = _lookahead( $subpath->[$sp] );
+					@head{ keys %$follow } = (values %$follow);
+					last unless exists $subpath->[$sp]{''};
+				}
+				else {
+					++$head{$subpath->[$sp]};
+					last;
+				}
+			}
+		}
+		else {
+			++$head{ $in->{$path}[0] };
+		}
+	}
+	# print "_lookahead ", _dump($in), '==>', _dump([keys %head]), "\n";
+	return \%head;
 }
 
 sub _re_path_lookahead {
-    my $self = shift;
-    my $in  = shift;
-    # print "_re_path_la in ", _dump($in), "\n";
-    my $out = '';
-    for( my $p = 0; $p < @$in; ++$p ) {
-        if( ref($in->[$p]) eq '' ) {
-            $out .= $in->[$p];
-            next;
-        }
-        elsif( ref($in->[$p]) eq 'ARRAY' ) {
-            $out .= _re_path_lookahead($self, $in->[$p]);
-            next;
-        }
-        # print "$p ", _dump($in->[$p]), "\n";
-        my $path = [
-            map { _re_path_lookahead($self, $in->[$p]{$_} ) }
-            grep { $_ ne '' }
-            keys %{$in->[$p]}
-        ];
-        my $ahead = _lookahead($in->[$p]);
-        my $more = 0;
-        if( exists $in->[$p]{''} and $p + 1 < @$in ) {
-            my $next = 1;
-            while( $p + $next < @$in ) {
-                if( ref( $in->[$p+$next] ) eq 'HASH' ) {
-                    my $follow = _lookahead( $in->[$p+$next] );
-                    @{$ahead}{ keys %$follow } = (values %$follow);
-                }
-                else {
-                    ++$ahead->{$in->[$p+$next]};
-                    last;
-                }
-                ++$next;
-            }
-            $more = 1;
-        }
-        my $nr_one = grep { /^$Single_Char$/ } @$path;
-        my $nr     = @$path;
-        if( $nr_one > 1 and $nr_one == $nr ) {
-            $out .= _make_class($self, @$path);
-            $out .= '?' if exists $in->[$p]{''};
-        }
-        else {
-            my $zwla = keys(%$ahead) > 1
-                ?  _combine($self, '?=', grep { s/\+$//; $_ } keys %$ahead )
-                : '';
-            my $patt = $nr > 1 ? _combine($self, '?:', @$path ) : $path->[0];
-            # print "have nr=$nr n1=$nr_one n=", _dump($in->[$p]), ' a=', _dump([keys %$ahead]), " zwla=$zwla patt=$patt @{[_dump($path)]}\n";
-            if( exists $in->[$p]{''} ) {
-                $out .=  $more ? "$zwla(?:$patt)?" : "(?:$zwla$patt)?";
-            }
-            else {
-                $out .= "$zwla$patt";
-            }
-        }
-    }
-    return $out;
+	my $self = shift;
+	my $in  = shift;
+	# print "_re_path_la in ", _dump($in), "\n";
+	my $out = '';
+	for( my $p = 0; $p < @$in; ++$p ) {
+		if( ref($in->[$p]) eq '' ) {
+			$out .= $in->[$p];
+			next;
+		}
+		elsif( ref($in->[$p]) eq 'ARRAY' ) {
+			$out .= _re_path_lookahead($self, $in->[$p]);
+			next;
+		}
+		# print "$p ", _dump($in->[$p]), "\n";
+		my $path = [
+			map { _re_path_lookahead($self, $in->[$p]{$_} ) }
+			grep { $_ ne '' }
+			keys %{$in->[$p]}
+		];
+		my $ahead = _lookahead($in->[$p]);
+		my $more = 0;
+		if( exists $in->[$p]{''} and $p + 1 < @$in ) {
+			my $next = 1;
+			while( $p + $next < @$in ) {
+				if( ref( $in->[$p+$next] ) eq 'HASH' ) {
+					my $follow = _lookahead( $in->[$p+$next] );
+					@{$ahead}{ keys %$follow } = (values %$follow);
+				}
+				else {
+					++$ahead->{$in->[$p+$next]};
+					last;
+				}
+				++$next;
+			}
+			$more = 1;
+		}
+		my $nr_one = grep { /^$Single_Char$/ } @$path;
+		my $nr     = @$path;
+		if( $nr_one > 1 and $nr_one == $nr ) {
+			$out .= _make_class($self, @$path);
+			$out .= '?' if exists $in->[$p]{''};
+		}
+		else {
+			my $zwla = keys(%$ahead) > 1
+				?  _combine($self, '?=', grep { s/\+$//; $_ } keys %$ahead )
+				: '';
+			my $patt = $nr > 1 ? _combine($self, '?:', @$path ) : $path->[0];
+			# print "have nr=$nr n1=$nr_one n=", _dump($in->[$p]), ' a=', _dump([keys %$ahead]), " zwla=$zwla patt=$patt @{[_dump($path)]}\n";
+			if( exists $in->[$p]{''} ) {
+				$out .=  $more ? "$zwla(?:$patt)?" : "(?:$zwla$patt)?";
+			}
+			else {
+				$out .= "$zwla$patt";
+			}
+		}
+	}
+	return $out;
 }
 
 sub _re_path_track {
-    my $self      = shift;
-    my $in        = shift;
-    my $normal    = shift;
-    my $augmented = shift;
-    my $o;
-    my $simple  = '';
-    my $augment = '';
-    for( my $n = 0; $n < @$in; ++$n ) {
-        if( ref($in->[$n]) eq '' ) {
-            $o = $in->[$n];
-            $simple  .= $o;
-            $augment .= $o;
-            if( (
-                    $n < @$in - 1
-                    and ref($in->[$n+1]) eq 'HASH' and exists $in->[$n+1]{''}
-                )
-                or $n == @$in - 1
-            ) {
-                push @{$self->{mlist}}, $normal . $simple ;
-                $augment .= $] < 5.009005
-                    ? "(?{\$self->{m}=$self->{mcount}})"
-                    : "(?{$self->{mcount}})"
-                ;
-                ++$self->{mcount};
-            }
-        }
-        else {
-            my $path = [
-                map { $self->_re_path_track( $in->[$n]{$_}, $normal.$simple , $augmented.$augment ) }
-                grep { $_ ne '' }
-                keys %{$in->[$n]}
-            ];
-            $o = '(?:' . join( '|' => sort _re_sort @$path ) . ')';
-            $o .= '?' if exists $in->[$n]{''};
-            $simple  .= $o;
-            $augment .= $o;
-        }
-    }
-    return $augment;
+	my $self      = shift;
+	my $in        = shift;
+	my $normal    = shift;
+	my $augmented = shift;
+	my $o;
+	my $simple  = '';
+	my $augment = '';
+	for( my $n = 0; $n < @$in; ++$n ) {
+		if( ref($in->[$n]) eq '' ) {
+			$o = $in->[$n];
+			$simple  .= $o;
+			$augment .= $o;
+			if( (
+					$n < @$in - 1
+					and ref($in->[$n+1]) eq 'HASH' and exists $in->[$n+1]{''}
+				)
+				or $n == @$in - 1
+			) {
+				push @{$self->{mlist}}, $normal . $simple ;
+				$augment .= $] < 5.009005
+					? "(?{\$self->{m}=$self->{mcount}})"
+					: "(?{$self->{mcount}})"
+				;
+				++$self->{mcount};
+			}
+		}
+		else {
+			my $path = [
+				map { $self->_re_path_track( $in->[$n]{$_}, $normal.$simple , $augmented.$augment ) }
+				grep { $_ ne '' }
+				keys %{$in->[$n]}
+			];
+			$o = '(?:' . join( '|' => sort _re_sort @$path ) . ')';
+			$o .= '?' if exists $in->[$n]{''};
+			$simple  .= $o;
+			$augment .= $o;
+		}
+	}
+	return $augment;
 }
 
 sub _re_path_pretty {
-    my $self = shift;
-    my $in  = shift;
-    my $arg = shift;
-    my $pre    = ' ' x (($arg->{depth}+0) * $arg->{indent});
-    my $indent = ' ' x (($arg->{depth}+1) * $arg->{indent});
-    my $out = '';
-    $arg->{depth}++;
-    my $prev_was_paren = 0;
-    for( my $p = 0; $p < @$in; ++$p ) {
-        if( ref($in->[$p]) eq '' ) {
-            $out .= "\n$pre" if $prev_was_paren;
-            $out .= $in->[$p];
-            $prev_was_paren = 0;
-        }
-        elsif( ref($in->[$p]) eq 'ARRAY' ) {
-            $out .= _re_path($self, $in->[$p]);
-        }
-        else {
-            my $path = [
-                map { _re_path_pretty($self, $in->[$p]{$_}, $arg ) }
-                grep { $_ ne '' }
-                keys %{$in->[$p]}
-            ];
-            my $nr = @$path;
-            my( @short, @long );
-            push @{/^$Single_Char$/ ? \@short : \@long}, $_ for @$path;
-            if( @short == $nr ) {
-                $out .=  $nr == 1 ? $path->[0] : _make_class($self, @short);
-                $out .= '?' if exists $in->[$p]{''};
-            }
-            else {
-                $out .= "\n" if length $out;
-                $out .= $pre if $p;
-                $out .= "(?:\n$indent";
-                if( @short < 2 ) {
-                    my $r = 0;
-                    $out .= join( "\n$indent|" => map {
-                            $r++ and $_ =~ s/^\(\?:/\n$indent(?:/;
-                            $_
-                        }
-                        sort _re_sort @$path
-                    );
-                }
-                else {
-                    $out .= join( "\n$indent|" => ( (sort _re_sort @long), _make_class($self, @short) ));
-                }
-                $out .= "\n$pre)";
-                if( exists $in->[$p]{''} ) {
-                    $out .= "\n$pre?";
-                    $prev_was_paren = 0;
-                }
-                else {
-                    $prev_was_paren = 1;
-                }
-            }
-        }
-    }
-    $arg->{depth}--;
-    return $out;
+	my $self = shift;
+	my $in  = shift;
+	my $arg = shift;
+	my $pre    = ' ' x (($arg->{depth}+0) * $arg->{indent});
+	my $indent = ' ' x (($arg->{depth}+1) * $arg->{indent});
+	my $out = '';
+	$arg->{depth}++;
+	my $prev_was_paren = 0;
+	for( my $p = 0; $p < @$in; ++$p ) {
+		if( ref($in->[$p]) eq '' ) {
+			$out .= "\n$pre" if $prev_was_paren;
+			$out .= $in->[$p];
+			$prev_was_paren = 0;
+		}
+		elsif( ref($in->[$p]) eq 'ARRAY' ) {
+			$out .= _re_path($self, $in->[$p]);
+		}
+		else {
+			my $path = [
+				map { _re_path_pretty($self, $in->[$p]{$_}, $arg ) }
+				grep { $_ ne '' }
+				keys %{$in->[$p]}
+			];
+			my $nr = @$path;
+			my( @short, @long );
+			push @{/^$Single_Char$/ ? \@short : \@long}, $_ for @$path;
+			if( @short == $nr ) {
+				$out .=  $nr == 1 ? $path->[0] : _make_class($self, @short);
+				$out .= '?' if exists $in->[$p]{''};
+			}
+			else {
+				$out .= "\n" if length $out;
+				$out .= $pre if $p;
+				$out .= "(?:\n$indent";
+				if( @short < 2 ) {
+					my $r = 0;
+					$out .= join( "\n$indent|" => map {
+							$r++ and $_ =~ s/^\(\?:/\n$indent(?:/;
+							$_
+						}
+						sort _re_sort @$path
+					);
+				}
+				else {
+					$out .= join( "\n$indent|" => ( (sort _re_sort @long), _make_class($self, @short) ));
+				}
+				$out .= "\n$pre)";
+				if( exists $in->[$p]{''} ) {
+					$out .= "\n$pre?";
+					$prev_was_paren = 0;
+				}
+				else {
+					$prev_was_paren = 1;
+				}
+			}
+		}
+	}
+	$arg->{depth}--;
+	return $out;
 }
 
 sub _node_eq {
-    return 0 if not defined $_[0] or not defined $_[1];
-    return 0 if ref $_[0] ne ref $_[1];
-    # Now that we have determined that the reference of each
-    # argument are the same, we only have to test the first
-    # one, which gives us a nice micro-optimisation.
-    if( ref($_[0]) eq 'HASH' ) {
-        keys %{$_[0]} == keys %{$_[1]}
-            and
-        # does this short-circuit to avoid _re_path() cost more than it saves?
-        join( '|' => sort keys %{$_[0]}) eq join( '|' => sort keys %{$_[1]})
-            and
-        _re_path(undef, [$_[0]] ) eq _re_path(undef, [$_[1]] );
-    }
-    elsif( ref($_[0]) eq 'ARRAY' ) {
-        scalar @{$_[0]} == scalar @{$_[1]}
-            and
-        _re_path(undef, $_[0]) eq _re_path(undef, $_[1]);
-    }
-    else {
-        $_[0] eq $_[1];
-    }
+	return 0 if not defined $_[0] or not defined $_[1];
+	return 0 if ref $_[0] ne ref $_[1];
+	# Now that we have determined that the reference of each
+	# argument are the same, we only have to test the first
+	# one, which gives us a nice micro-optimisation.
+	if( ref($_[0]) eq 'HASH' ) {
+		keys %{$_[0]} == keys %{$_[1]}
+			and
+		# does this short-circuit to avoid _re_path() cost more than it saves?
+		join( '|' => sort keys %{$_[0]}) eq join( '|' => sort keys %{$_[1]})
+			and
+		_re_path(undef, [$_[0]] ) eq _re_path(undef, [$_[1]] );
+	}
+	elsif( ref($_[0]) eq 'ARRAY' ) {
+		scalar @{$_[0]} == scalar @{$_[1]}
+			and
+		_re_path(undef, $_[0]) eq _re_path(undef, $_[1]);
+	}
+	else {
+		$_[0] eq $_[1];
+	}
 }
 
 sub _pretty_dump {
-    return sprintf "\\x%02x", ord(shift);
+	return sprintf "\\x%02x", ord(shift);
 }
 
 sub _dump {
-    my $path = shift;
-    return _dump_node($path) if ref($path) eq 'HASH';
-    my $dump = '[';
-    my $d;
-    my $nr = 0;
-    for $d( @$path ) {
-        $dump .= ' ' if $nr++;
-        if( ref($d) eq 'HASH' ) {
-            $dump .= _dump_node($d);
-        }
-        elsif( ref($d) eq 'ARRAY' ) {
-            $dump .= _dump($d);
-        }
-        elsif( defined $d ) {
-            # D::C indicates the second test is redundant
-            # $dump .= ( $d =~ /\s/ or not length $d )
-            $dump .= (
-                $d =~ /\s/            ? qq{'$d'}         :
-                $d =~ /^[\x00-\x1f]$/ ? _pretty_dump($d) :
-                $d
-            );
-        }
-        else {
-            $dump .= '*';
-        }
-    }
-    return $dump . ']';
+	my $path = shift;
+	return _dump_node($path) if ref($path) eq 'HASH';
+	my $dump = '[';
+	my $d;
+	my $nr = 0;
+	for $d( @$path ) {
+		$dump .= ' ' if $nr++;
+		if( ref($d) eq 'HASH' ) {
+			$dump .= _dump_node($d);
+		}
+		elsif( ref($d) eq 'ARRAY' ) {
+			$dump .= _dump($d);
+		}
+		elsif( defined $d ) {
+			# D::C indicates the second test is redundant
+			# $dump .= ( $d =~ /\s/ or not length $d )
+			$dump .= (
+				$d =~ /\s/            ? qq{'$d'}         :
+				$d =~ /^[\x00-\x1f]$/ ? _pretty_dump($d) :
+				$d
+			);
+		}
+		else {
+			$dump .= '*';
+		}
+	}
+	return $dump . ']';
 }
 
 sub _dump_node {
-    my $node = shift;
-    my $dump = '{';
-    my $nr   = 0;
-    my $n;
-    for $n (sort keys %$node) {
-        $dump .= ' ' if $nr++;
-        # Devel::Cover shows this to test to be redundant
-        # $dump .= ( $n eq '' and not defined $node->{$n} )
-        $dump .= $n eq ''
-            ? '*'
-            : ($n =~ /^[\x00-\x1f]$/ ? _pretty_dump($n) : $n)
-                . "=>" . _dump($node->{$n})
-        ;
-    }
-    return $dump . '}';
+	my $node = shift;
+	my $dump = '{';
+	my $nr   = 0;
+	my $n;
+	for $n (sort keys %$node) {
+		$dump .= ' ' if $nr++;
+		# Devel::Cover shows this to test to be redundant
+		# $dump .= ( $n eq '' and not defined $node->{$n} )
+		$dump .= $n eq ''
+			? '*'
+			: ($n =~ /^[\x00-\x1f]$/ ? _pretty_dump($n) : $n)
+				. "=>" . _dump($node->{$n})
+		;
+	}
+	return $dump . '}';
 }
 
 =pod
@@ -2059,20 +2059,20 @@ curly), a character split will be performed directly.
 A list of strings may be supplied, thus you can pass it a file
 handle of a file opened for reading:
 
-    $re->add( '\d+-\d+-\d+-\d+\.example\.com' );
-    $re->add( <IN> );
+	$re->add( '\d+-\d+-\d+-\d+\.example\.com' );
+	$re->add( <IN> );
 
 If the file is very large, it may be more efficient to use a
 C<while> loop, to read the file line-by-line:
 
-    $re->add($_) while <IN>;
+	$re->add($_) while <IN>;
 
 The C<add> method will chomp the lines automatically. If you
 do not want this to occur (you want to keep the record
 separator), then disable C<chomp>ing.
 
-    $re->chomp(0);
-    $re->add($_) while <IN>;
+	$re->chomp(0);
+	$re->add($_) while <IN>;
 
 This method is chainable.
 
@@ -2123,8 +2123,8 @@ English variable names).
 =back
 
   $r->add_file( {
-    file => [ 'pattern.txt', 'more.txt' ],
-    input_record_separator  => "\r\n",
+	file => [ 'pattern.txt', 'more.txt' ],
+	input_record_separator  => "\r\n",
   });
 
 =head2 clone()
@@ -2153,8 +2153,8 @@ a list of tokens, I<e.g.> C<('a', 'b+', 'c?', 'd*', 'e')>.
 This method is chainable, I<e.g.>:
 
   my $ra = Regexp::Assemble->new
-    ->insert( qw[ a b+ c? d* e ] )
-    ->insert( qw[ a c+ d+ e* f ] );
+	->insert( qw[ a b+ c? d* e ] )
+	->insert( qw[ a c+ d+ e* f ] );
 
 Lexing complex patterns with metacharacters and so on can consume
 a significant proportion of the overall time to build an assembly.
@@ -2219,7 +2219,7 @@ the following:
 or
 
   sub only_spaces_and_digits {
-    not grep { ![\d ] } @_
+	not grep { ![\d ] } @_
   }
   $ra->filter( \&only_spaces_and_digits );
 
@@ -2278,16 +2278,16 @@ With method chaining, it is possible to produce a RE without having
 a temporary C<Regexp::Assemble> object lying around, I<e.g.>:
 
   my $re = Regexp::Assemble->new
-    ->add( q[ab+cd+e] )
-    ->add( q[ac\\d+e] )
-    ->add( q[c\\d+e] )
-    ->re;
+	->add( q[ab+cd+e] )
+	->add( q[ac\\d+e] )
+	->add( q[c\\d+e] )
+	->re;
 
 The C<$re> variable now contains a Regexp object that can be used
 directly:
 
   while( <> ) {
-    /$re/ and print "Something in [$_] matched\n";
+	/$re/ and print "Something in [$_] matched\n";
   )
 
 The C<re> method is called when the object is used in string context
@@ -2297,9 +2297,9 @@ as expected:
 
   my $re = Regexp::Assemble->new->add( qw[ fee fie foe fum ] );
   while( <IN> ) {
-    if( /($re)/ ) {
-      print "Here be giants: $1\n";
-    }
+	if( /($re)/ ) {
+	  print "Here be giants: $1\n";
+	}
   }
 
 This approach does not work with tracked patterns. The
@@ -2314,10 +2314,10 @@ If pattern tracking is in use, you must C<use re 'eval'> in order
 to make things work correctly. At a minimum, this will make your
 code look like this:
 
-    my $did_match = do { use re 'eval'; $target =~ /$ra/ }
-    if( $did_match ) {
-        print "matched ", $ra->matched, "\n";
-    }
+	my $did_match = do { use re 'eval'; $target =~ /$ra/ }
+	if( $did_match ) {
+		print "matched ", $ra->matched, "\n";
+	}
 
 (The main reason is that the C<$^R> variable is currently broken
 and an ugly workaround that runs some Perl code during the match
@@ -2340,7 +2340,7 @@ supply the necessary context to take care of the tracking housekeeping
 details.
 
    if( defined( my $match = $ra->match($_)) ) {
-       print "  $_ matched by $match\n";
+	   print "  $_ matched by $match\n";
    }
 
 In the case of a successful match, the original matched pattern
@@ -2470,12 +2470,12 @@ tracked mode, this method returns C<undef>.
   my $r = Regexp::Assemble->new->track(1)->add(qw(foo? bar{2} [Rr]at));
 
   for my $w (qw(this food is rather barren)) {
-    if ($w =~ /$r/) {
-      print "$w matched by ", $r->source($^R), $/;
-    }
-    else {
-      print "$w no match\n";
-    }
+	if ($w =~ /$r/) {
+	  print "$w matched by ", $r->source($^R), $/;
+	}
+	else {
+	  print "$w no match\n";
+	}
   }
 
 =head2 mbegin()
@@ -2582,11 +2582,11 @@ the code will be executed and it will receive a reference
 to the object in question, and the lexed pattern.
 
   $r->dup_warn(
-    sub {
-      my $self = shift;
-      print $self->stats_add, " patterns added at line $.\n",
-          join( '', @_ ), " added previously\n";
-    }
+	sub {
+	  my $self = shift;
+	  print $self->stats_add, " patterns added at line $.\n",
+		  join( '', @_ ), " added previously\n";
+	}
   )
 
 =head2 Anchor routines
@@ -2635,8 +2635,8 @@ word boundary assertion when the value is true. Set
 to 0 to disable.
 
   $r->add(qw(ing tion))
-    ->anchor_word_end
-    ->as_string; # produces '(?:tion|ing)\b'
+	->anchor_word_end
+	->as_string; # produces '(?:tion|ing)\b'
 
 =head2 anchor_word
 
@@ -2646,8 +2646,8 @@ of the pattern when the value is true. Set
 to 0 to disable.
 
   $r->add(qw(cat carrot)
-    ->anchor_word(1)
-    ->as_string; # produces '\bca(?:rro)t\b'
+	->anchor_word(1)
+	->as_string; # produces '\bca(?:rro)t\b'
 
 =head2 anchor_line_begin
 
@@ -2676,8 +2676,8 @@ of the pattern, respectively, when the value is true. Set
 to 0 to disable.
 
   $r->add(qw(cat carrot)
-    ->anchor_line
-    ->as_string; # produces '^ca(?:rro)t$'
+	->anchor_line
+	->as_string; # produces '^ca(?:rro)t$'
 
 =head2 anchor_string_begin
 
@@ -2717,8 +2717,8 @@ of the pattern, respectively, when the value is true. Set
 to 0 to disable.
 
   $r->add(qw(cat carrot)
-    ->anchor_string
-    ->as_string; # produces '\Aca(?:rro)t\Z'
+	->anchor_string
+	->as_string; # produces '\Aca(?:rro)t\Z'
 
 =head2 anchor_string_absolute
 
@@ -2728,8 +2728,8 @@ of the pattern, respectively, when the value is true. Set
 to 0 to disable.
 
   $r->add(qw(cat carrot)
-    ->anchor_string_absolute
-    ->as_string; # produces '\Aca(?:rro)t\z'
+	->anchor_string_absolute
+	->as_string; # produces '\Aca(?:rro)t\z'
 
 =head2 debug(NUMBER)
 
@@ -2870,7 +2870,7 @@ one that caused the match.
 
   $re->track( 1 );
   if( $target =~ /$re/ ) {
-    print "$target matched by ", $re->matched, "\n";
+	print "$target matched by ", $re->matched, "\n";
   }
 
 Note that when this functionality is enabled, no
@@ -2930,7 +2930,7 @@ pattern. If the pattern fails to match all parts of the string,
 the missing parts will be returned as single chunks. Therefore
 the following pattern is legal (albeit rather cork-brained):
 
-    Regexp::Assemble::Default_Lexer( '\\d' );
+	Regexp::Assemble::Default_Lexer( '\\d' );
 
 The above pattern will split up input strings digit by digit, and
 all non-digit characters as single chunks.
@@ -3330,55 +3330,55 @@ I'm rewriting the reduction code using this technique.
 12. utf-8... hmmmm...
 
 14. Adding qr//'ed patterns. For example, consider
-    $r->add ( qr/^abc/i )
-        ->add( qr/^abd/ )
-        ->add( qr/^ab e/x );
-    this should admit abc abC aBc aBC abd abe as matches
+	$r->add ( qr/^abc/i )
+		->add( qr/^abd/ )
+		->add( qr/^ab e/x );
+	this should admit abc abC aBc aBC abd abe as matches
 
 16. Allow a fast, unsafe tracking mode, that can be used if a(?bc)?
-    can't happen. (Possibly carp if it does appear during traversal)?
+	can't happen. (Possibly carp if it does appear during traversal)?
 
 17. given a-\d+-\d+-\d+-\d+-b, produce a(?:-\d+){4}-b. Something
-    along the lines of (.{4))(\1+) would let the regexp engine
-    itself be brought to bear on the matter, which is a rather
-    appealing idea. Consider
+	along the lines of (.{4))(\1+) would let the regexp engine
+	itself be brought to bear on the matter, which is a rather
+	appealing idea. Consider
 
-      while(/(?!\+)(\S{2,}?)(\1+)/g) { ... $1, $2 ... }
+	  while(/(?!\+)(\S{2,}?)(\1+)/g) { ... $1, $2 ... }
 
-    as a starting point.
+	as a starting point.
 
 19. The reduction code has become unbelievably baroque. Adding code
-    to handle (sting,singing,sing) => s(?:(?:ing)?|t)ing was far
-    too difficult. Adding more stuff just breaks existing behaviour.
-    And fixing the ^abcd$ ... bug broke stuff all over again.
-    Now that the corner cases are more clearly identified, a full
-    rewrite of the reduction code is needed. And would admit the
-    possibility of implementing items 1 and 17.
+	to handle (sting,singing,sing) => s(?:(?:ing)?|t)ing was far
+	too difficult. Adding more stuff just breaks existing behaviour.
+	And fixing the ^abcd$ ... bug broke stuff all over again.
+	Now that the corner cases are more clearly identified, a full
+	rewrite of the reduction code is needed. And would admit the
+	possibility of implementing items 1 and 17.
 
 20. Handle debug unrev with a separate bit
 
 23. Japhy's http://www.perlmonks.org/index.pl?node_id=90876 list2range
-    regexp
+	regexp
 
 24. Lookahead assertions contain serious bugs (as shown by
-    assembling powersets. Need to save more context during reduction,
-    which in turn will simplify the preparation of the lookahead
-    classes. See also 19.
+	assembling powersets. Need to save more context during reduction,
+	which in turn will simplify the preparation of the lookahead
+	classes. See also 19.
 
 26. _lex() swamps the overall run-time. It stems from the decision
-    to use a single regexp to pull apart any pattern. A suite of
-    simpler regexp to pick of parens, char classes, quantifiers
-    and bare tokens may be faster. (This has been implemented as
+	to use a single regexp to pull apart any pattern. A suite of
+	simpler regexp to pick of parens, char classes, quantifiers
+	and bare tokens may be faster. (This has been implemented as
 	_fastlex(), but it's only marginally faster. Perhaps split-by-
 	char and lex a la C?
 
 27. We don't, as yet, unroll_plus a paren e.g. (abc)+?
 
 28. We don't reroll unrolled a a* to a+ in indented or tracked
-    output
+	output
 
 29. Use (*MARK n) in blead for tracked patterns, and use (*FAIL) for
-    the unmatchable pattern.
+	the unmatchable pattern.
 
 =head1 LICENSE
 

--- a/t/00_basic.t
+++ b/t/00_basic.t
@@ -25,162 +25,162 @@ ok( defined($rt), 'new() defines something' );
 is( ref($rt), 'Regexp::Assemble', 'new() returns a Regexp::Assemble object' );
 
 cmp_ok( length(Regexp::Assemble::Default_Lexer), '>', 0,
-    'default lexer is something' );
+	'default lexer is something' );
 
 is( ref( $rt->_path ), 'ARRAY', '_path() isa ARRAY' );
 is( scalar @{$rt->_path}, 0, '_path() is empty' );
 
 {
-    my $r = Regexp::Assemble->new( chomp => 1 );
-    is( $r->{chomp}, 1, 'chomp new(1)' );
-    $r->chomp( 0 );
-    is( $r->{chomp}, 0, 'chomp(0)' );
-    $r->chomp();
-    is( $r->{chomp}, 1, 'chomp()' );
+	my $r = Regexp::Assemble->new( chomp => 1 );
+	is( $r->{chomp}, 1, 'chomp new(1)' );
+	$r->chomp( 0 );
+	is( $r->{chomp}, 0, 'chomp(0)' );
+	$r->chomp();
+	is( $r->{chomp}, 1, 'chomp()' );
 }
 
 {
-    my $r = Regexp::Assemble->new( indent => 1 );
-    is( $r->{indent}, 1, 'indent new(1)' );
-    $r->indent( 4 );
-    is( $r->{indent}, 4, 'indent(4)' );
-    $r->indent();
-    is( $r->{indent}, 0, 'indent()' );
+	my $r = Regexp::Assemble->new( indent => 1 );
+	is( $r->{indent}, 1, 'indent new(1)' );
+	$r->indent( 4 );
+	is( $r->{indent}, 4, 'indent(4)' );
+	$r->indent();
+	is( $r->{indent}, 0, 'indent()' );
 }
 
 {
-    my $r = Regexp::Assemble->new( reduce => 1 );
-    is( $r->{reduce}, 1, 'reduce new(1)' );
-    $r->reduce( 0 );
-    is( $r->{reduce}, 0, 'reduce(0)' );
-    $r->reduce();
-    is( $r->{reduce}, 1, 'reduce()' );
+	my $r = Regexp::Assemble->new( reduce => 1 );
+	is( $r->{reduce}, 1, 'reduce new(1)' );
+	$r->reduce( 0 );
+	is( $r->{reduce}, 0, 'reduce(0)' );
+	$r->reduce();
+	is( $r->{reduce}, 1, 'reduce()' );
 }
 
 {
-    my $r = Regexp::Assemble->new( mutable => 1 );
-    is( $r->{mutable}, 1, 'mutable new(1)' );
-    $r->mutable( 0 );
-    is( $r->{mutable}, 0, 'mutable(0)' );
-    $r->mutable();
-    is( $r->{mutable}, 1, 'mutable()' );
+	my $r = Regexp::Assemble->new( mutable => 1 );
+	is( $r->{mutable}, 1, 'mutable new(1)' );
+	$r->mutable( 0 );
+	is( $r->{mutable}, 0, 'mutable(0)' );
+	$r->mutable();
+	is( $r->{mutable}, 1, 'mutable()' );
 }
 
 {
-    my $r = Regexp::Assemble->new( flags => 'i' );
-    is( $r->{flags}, 'i', 'flags new(i)' );
-    $r->flags( 'sx' );
-    is( $r->{flags}, 'sx', 'flags(sx)' );
-    $r->flags( '' );
-    is( $r->{flags}, '', q{flags('')} );
-    $r->flags( 0 );
-    is( $r->{flags}, '0', 'flags(0)' );
-    $r->flags();
-    is( $r->{flags}, '', q{flags()} );
+	my $r = Regexp::Assemble->new( flags => 'i' );
+	is( $r->{flags}, 'i', 'flags new(i)' );
+	$r->flags( 'sx' );
+	is( $r->{flags}, 'sx', 'flags(sx)' );
+	$r->flags( '' );
+	is( $r->{flags}, '', q{flags('')} );
+	$r->flags( 0 );
+	is( $r->{flags}, '0', 'flags(0)' );
+	$r->flags();
+	is( $r->{flags}, '', q{flags()} );
 }
 
 {
-    my $r = Regexp::Assemble->new( modifiers => 'i' );
-    is( $r->{flags}, 'i', 'modifiers flags new(i)' );
-    $r->modifiers( 'sx' );
-    is( $r->{flags}, 'sx', 'modifiers flags(sx)' );
-    $r->modifiers( '' );
-    is( $r->{flags}, '', q{modifiers flags('')} );
-    $r->modifiers( 0 );
-    is( $r->{flags}, '0', 'modifiers flags(0)' );
-    $r->modifiers();
-    is( $r->{flags}, '', q{modifiers flags()} );
+	my $r = Regexp::Assemble->new( modifiers => 'i' );
+	is( $r->{flags}, 'i', 'modifiers flags new(i)' );
+	$r->modifiers( 'sx' );
+	is( $r->{flags}, 'sx', 'modifiers flags(sx)' );
+	$r->modifiers( '' );
+	is( $r->{flags}, '', q{modifiers flags('')} );
+	$r->modifiers( 0 );
+	is( $r->{flags}, '0', 'modifiers flags(0)' );
+	$r->modifiers();
+	is( $r->{flags}, '', q{modifiers flags()} );
 }
 
 {
-    my $r = Regexp::Assemble->new( track => 2 );
-    is( $r->{track}, 2, 'track new(n)' );
-    $r->track( 0 );
-    is( $r->{track}, 0, 'track(0)' );
-    $r->track( 1 );
-    is( $r->{track}, 1, 'track(1)' );
-    $r->track( 0 );
-    is( $r->{track}, 0, 'track(0) 2nd' );
-    $r->track();
-    is( $r->{track}, 1, 'track()' );
+	my $r = Regexp::Assemble->new( track => 2 );
+	is( $r->{track}, 2, 'track new(n)' );
+	$r->track( 0 );
+	is( $r->{track}, 0, 'track(0)' );
+	$r->track( 1 );
+	is( $r->{track}, 1, 'track(1)' );
+	$r->track( 0 );
+	is( $r->{track}, 0, 'track(0) 2nd' );
+	$r->track();
+	is( $r->{track}, 1, 'track()' );
 }
 
 {
-    my $r = Regexp::Assemble->new( mutable => 2 );
-    is( $r->{mutable}, 2, 'mutable new(n)' );
-    $r->mutable( 0 );
-    is( $r->{mutable}, 0, 'track(0)' );
+	my $r = Regexp::Assemble->new( mutable => 2 );
+	is( $r->{mutable}, 2, 'mutable new(n)' );
+	$r->mutable( 0 );
+	is( $r->{mutable}, 0, 'track(0)' );
 }
 
 {
-    my $r = Regexp::Assemble->new( reduce => 2 );
-    is( $r->{reduce}, 2, 'reduce new(n)' );
-    $r->reduce( 0 );
-    is( $r->{reduce}, 0, 'reduce(0)' );
+	my $r = Regexp::Assemble->new( reduce => 2 );
+	is( $r->{reduce}, 2, 'reduce new(n)' );
+	$r->reduce( 0 );
+	is( $r->{reduce}, 0, 'reduce(0)' );
 }
 
 {
-    my $r = Regexp::Assemble->new( pre_filter => sub { undef } );
-    is( ref($r->{pre_filter}), 'CODE', 'pre_filter new(n)' );
-    $r->pre_filter( undef );
-    ok( !defined $r->{pre_filter}, 'pre_filter(0)' );
+	my $r = Regexp::Assemble->new( pre_filter => sub { undef } );
+	is( ref($r->{pre_filter}), 'CODE', 'pre_filter new(n)' );
+	$r->pre_filter( undef );
+	ok( !defined $r->{pre_filter}, 'pre_filter(0)' );
 }
 
 {
-    my $r = Regexp::Assemble->new( filter => sub { undef } );
-    is( ref($r->{filter}), 'CODE', 'filter new(n)' );
-    $r->filter( undef );
-    ok( !defined $r->{filter}, 'filter(0)' );
+	my $r = Regexp::Assemble->new( filter => sub { undef } );
+	is( ref($r->{filter}), 'CODE', 'filter new(n)' );
+	$r->filter( undef );
+	ok( !defined $r->{filter}, 'filter(0)' );
 }
 
 is( Regexp::Assemble::_node_key(
-        { a => 1, b=>2, c=>3 }
-    ), 'a', '_node_key(1)'
+		{ a => 1, b=>2, c=>3 }
+	), 'a', '_node_key(1)'
 );
 
 is( Regexp::Assemble::_node_key(
-        { b => 3, c=>2, z=>1 }
-    ), 'b', '_node_key(2)'
+		{ b => 3, c=>2, z=>1 }
+	), 'b', '_node_key(2)'
 );
 
 is( Regexp::Assemble::_node_key(
-        { a => 1, 'a.' => 2, b => 3 }
-    ), 'a', '_node_key(3)'
+		{ a => 1, 'a.' => 2, b => 3 }
+	), 'a', '_node_key(3)'
 );
 
 is( Regexp::Assemble::_node_key(
-        { '' => undef, a => 1, 'a.' => 2, b => 3 }
-    ), 'a', '_node_key(4)'
+		{ '' => undef, a => 1, 'a.' => 2, b => 3 }
+	), 'a', '_node_key(4)'
 );
 
 is( Regexp::Assemble::_node_key(
-        { '' => undef, abc => 1, def => 2, g => 3 }
-    ), 'abc', '_node_key(5)'
+		{ '' => undef, abc => 1, def => 2, g => 3 }
+	), 'abc', '_node_key(5)'
 );
 
 is( Regexp::Assemble::_node_offset(
-        [ 'a', 'b', '\\d+', 'e', '\\d' ]
-    ), -1, '_node_offset(1)'
+		[ 'a', 'b', '\\d+', 'e', '\\d' ]
+	), -1, '_node_offset(1)'
 );
 
 is( Regexp::Assemble::_node_offset(
-        [ {x => ['x'], '' => undef}, 'a', 'b', '\\d+', 'e', '\\d' ]
-    ), 0, '_node_offset(2)'
+		[ {x => ['x'], '' => undef}, 'a', 'b', '\\d+', 'e', '\\d' ]
+	), 0, '_node_offset(2)'
 );
 
 is( Regexp::Assemble::_node_offset(
-        [ 'a', 'b', '\\d+', 'e', {a => 1, b => 2}, 'x', 'y', 'z' ]
-    ), 4, '_node_offset(3)'
+		[ 'a', 'b', '\\d+', 'e', {a => 1, b => 2}, 'x', 'y', 'z' ]
+	), 4, '_node_offset(3)'
 );
 
 is( Regexp::Assemble::_node_offset(
-        [ { z => 1, x => 2 }, 'b', '\\d+', 'e', {a => 1, b => 2}, 'z' ]
-    ), 0, '_node_offset(4)'
+		[ { z => 1, x => 2 }, 'b', '\\d+', 'e', {a => 1, b => 2}, 'z' ]
+	), 0, '_node_offset(4)'
 );
 
 is( Regexp::Assemble::_node_offset(
-        [ [ 1, 2, 3, {a => ['a'], b=>['b']} ], 'a', { z => 1, x => 2 } ]
-    ), 2, '_node_offset(5)'
+		[ [ 1, 2, 3, {a => ['a'], b=>['b']} ], 'a', { z => 1, x => 2 } ]
+	), 2, '_node_offset(5)'
 );
 
 is( Regexp::Assemble::_node_eq(     {},     {}), 1, '{} eq {}');
@@ -196,153 +196,153 @@ is( Regexp::Assemble::_node_eq([0,1,2],[0,1,3]), '', 'ne [0,1,2]');
 is( Regexp::Assemble::_node_eq(  [1,2],[0,1,2]), '', 'ne [1,2]');
 
 is( Regexp::Assemble::_node_eq(
-        {'a'=>['a','b']},
-        {'a'=>['a','b']},
-    ), 1, 'eq {a}'
+		{'a'=>['a','b']},
+		{'a'=>['a','b']},
+	), 1, 'eq {a}'
 );
 
 is( Regexp::Assemble::_node_eq(
-        {'a'=>['a','b']},
-        {'a'=>['a','b'], '' => undef},
-    ), '', 'ne {a}'
+		{'a'=>['a','b']},
+		{'a'=>['a','b'], '' => undef},
+	), '', 'ne {a}'
 );
 
 is( Regexp::Assemble::_node_eq(
-        {'a'=>['a','b'], 'b'=>['b','c']},
-        {'a'=>['a','b'], 'b'=>['b','c']},
-    ), 1, 'eq {a,b}'
+		{'a'=>['a','b'], 'b'=>['b','c']},
+		{'a'=>['a','b'], 'b'=>['b','c']},
+	), 1, 'eq {a,b}'
 );
 
 is( Regexp::Assemble::_node_eq(
-        {'a'=>['a','b'], 'b'=>['b','c']},
-        {'a'=>['a','b'], 'b'=>['b','d']},
-    ), '', 'ne {a,b}'
+		{'a'=>['a','b'], 'b'=>['b','c']},
+		{'a'=>['a','b'], 'b'=>['b','d']},
+	), '', 'ne {a,b}'
 );
 
 is( Regexp::Assemble::_node_eq(
-        [{'a'=>['a','b'], 'b'=>['b','c']}, {'z'=>['z','y'], 'm'=>['m','n']}],
-        [{'a'=>['a','b'], 'b'=>['b','c']}, {'z'=>['z','y'], 'm'=>['m','n']}],
-    ), 1, 'eq {a,b},{z,m}'
+		[{'a'=>['a','b'], 'b'=>['b','c']}, {'z'=>['z','y'], 'm'=>['m','n']}],
+		[{'a'=>['a','b'], 'b'=>['b','c']}, {'z'=>['z','y'], 'm'=>['m','n']}],
+	), 1, 'eq {a,b},{z,m}'
 );
 
 is( Regexp::Assemble::_node_eq(
-        [{'a'=>['a','b'], 'b'=>['b','c']}, {'z'=>['z','y'], 'm'=>['m','n']}],
-        [{'a'=>['a','b'], 'b'=>['b','c']}, {'z'=>['z','y'], 'm'=>['m','n','o']}],
-    ), '', 'ne {a,b},{z,m}'
+		[{'a'=>['a','b'], 'b'=>['b','c']}, {'z'=>['z','y'], 'm'=>['m','n']}],
+		[{'a'=>['a','b'], 'b'=>['b','c']}, {'z'=>['z','y'], 'm'=>['m','n','o']}],
+	), '', 'ne {a,b},{z,m}'
 );
 
 is( Regexp::Assemble::_node_eq(
-        {''=>undef, 'a'=>['a','b']},
-        {''=>undef, 'a'=>['a','b']},
-    ), 1, '{eq {* a}'
+		{''=>undef, 'a'=>['a','b']},
+		{''=>undef, 'a'=>['a','b']},
+	), 1, '{eq {* a}'
 );
 
 is( Regexp::Assemble::_node_eq(
-        {''=>undef, 'a'=>['a','b']},
-        {''=>undef, 'a'=>['a','b','c']},
-    ), '', '{ne {* a}'
+		{''=>undef, 'a'=>['a','b']},
+		{''=>undef, 'a'=>['a','b','c']},
+	), '', '{ne {* a}'
 );
 
 is( Regexp::Assemble::_node_eq(
-        ['z','\\d+', {'a'=>['a','b']}],
-        ['z','\\d+', {'a'=>['a','b']}],
-    ), 1, 'eq [z \d+ {a}]'
+		['z','\\d+', {'a'=>['a','b']}],
+		['z','\\d+', {'a'=>['a','b']}],
+	), 1, 'eq [z \d+ {a}]'
 );
 
 is( Regexp::Assemble::_node_eq(
-        ['z','\\d+', {'a'=>['a','b'], 'z'=>['z','y','x']}],
-        ['z','\\d+', {'a'=>['a','b'], 'z'=>['z','y','x']}],
-    ), 1, 'eq [z \d+ {a,z}]'
+		['z','\\d+', {'a'=>['a','b'], 'z'=>['z','y','x']}],
+		['z','\\d+', {'a'=>['a','b'], 'z'=>['z','y','x']}],
+	), 1, 'eq [z \d+ {a,z}]'
 );
 
 my $stub = Regexp::Assemble->new;
 
 is( Regexp::Assemble::_make_class($stub, qw/ a b c / ),
-    '[abc]', '_make_class a b c'
+	'[abc]', '_make_class a b c'
 );
 
 is( Regexp::Assemble::_make_class($stub, qw/ a a c / ),
-    '[ac]', '_make_class a a c'
+	'[ac]', '_make_class a a c'
 );
 
 is( Regexp::Assemble::_make_class($stub, qw/ 0 1 2 / ),
-    '[012]', '_make_class 0 1 2'
+	'[012]', '_make_class 0 1 2'
 );
 
 is( Regexp::Assemble::_make_class($stub, qw/ 0 1 2 3 4 5 6 7 8 9 / ),
-    '\\d', '_make_class 0 1 ... 9'
+	'\\d', '_make_class 0 1 ... 9'
 );
 
 is( Regexp::Assemble::_make_class($stub, '\\d', '\\D' ),
-    '.', '_make_class \\d \\D'
+	'.', '_make_class \\d \\D'
 );
 
 is( Regexp::Assemble::_make_class($stub, '\\s', '\\S' ),
-    '.', '_make_class \\s \\S'
+	'.', '_make_class \\s \\S'
 );
 
 is( Regexp::Assemble::_make_class($stub, '\\w', '\\W' ),
-    '.', '_make_class \\w \\W'
+	'.', '_make_class \\w \\W'
 );
 
 is( Regexp::Assemble::_make_class($stub, '\\w', '\\d' ),
-    '\\w', '_make_class \\w \\d'
+	'\\w', '_make_class \\w \\d'
 );
 
 is( Regexp::Assemble::_make_class($stub, '\\W', '\\D' ),
-    '\\W', '_make_class \\W \\D'
+	'\\W', '_make_class \\W \\D'
 );
 
 is( Regexp::Assemble::_make_class($stub, '\\W', '\\d' ),
-    '[\\W\\d]', '_make_class \\W \\d'
+	'[\\W\\d]', '_make_class \\W \\d'
 );
 
 is( Regexp::Assemble::_make_class($stub, '\\d', qw/5 a / ),
-    '[\\da]', '_make_class \\d 5 a'
+	'[\\da]', '_make_class \\d 5 a'
 );
 
 is( Regexp::Assemble::_make_class($stub, qw/ a z - / ),
-    '[-az]', '_make_class a z -'
+	'[-az]', '_make_class a z -'
 );
 
 is( Regexp::Assemble::_make_class($stub, qw/ a z ^ / ),
-    '[az^]', '_make_class a z ^'
+	'[az^]', '_make_class a z ^'
 );
 
 is( Regexp::Assemble::_make_class($stub, qw/ a z ^ - / ),
-    '[-az^]', '_make_class a z ^ -'
+	'[-az^]', '_make_class a z ^ -'
 );
 
 is( Regexp::Assemble::_make_class($stub, '\\.', '\\+' ),
-    '[+.]', '_make_class \\. \\+'
+	'[+.]', '_make_class \\. \\+'
 );
 
 $stub->fold_meta_pairs(0);
 
 is( Regexp::Assemble::_make_class($stub, '\\d', '\\D' ),
-    '[\\D\\d]', '_make_class \\d \\D no fold meta pairs'
+	'[\\D\\d]', '_make_class \\d \\D no fold meta pairs'
 );
 
 is( Regexp::Assemble::_make_class($stub, '\\s', '\\S' ),
-    '[\\S\\s]', '_make_class \\s \\S no fold meta pairs'
+	'[\\S\\s]', '_make_class \\s \\S no fold meta pairs'
 );
 
 is( Regexp::Assemble::_make_class($stub, '\\w', '\\W' ),
-    '[\\W\\w]', '_make_class \\w \\W no fold meta pairs'
+	'[\\W\\w]', '_make_class \\w \\W no fold meta pairs'
 );
 
 $stub->fold_meta_pairs();
 
 is( Regexp::Assemble::_make_class($stub, '\\s', '\\S' ),
-    '.', '_make_class \\s \\S implicit fold_meta_pairs'
+	'.', '_make_class \\s \\S implicit fold_meta_pairs'
 );
 
 sub xcmp {
-    my $r = Regexp::Assemble->new;
-    is_deeply(
-        $r->_lex( $_[0] ), [ $_[1] ],
-        sprintf( '_lex \\x%02x', ord( $_[1] ))
-    );
+	my $r = Regexp::Assemble->new;
+	is_deeply(
+		$r->_lex( $_[0] ), [ $_[1] ],
+		sprintf( '_lex \\x%02x', ord( $_[1] ))
+	);
 }
 
 xcmp( '\x20', ' ' );
@@ -387,11 +387,11 @@ xcmp( '\x7e', '~' );
 xcmp( '\x7f', '' );
 
 sub lcmp {
-    is_deeply(
-        Regexp::Assemble->new->_lex( $_[0] ),
-        [ $_[0] ],
-        "_lex $_[0] source line $_[1]"
-    );
+	is_deeply(
+		Regexp::Assemble->new->_lex( $_[0] ),
+		[ $_[0] ],
+		"_lex $_[0] source line $_[1]"
+	);
 }
 
 lcmp( 'X?', __LINE__ );
@@ -503,255 +503,255 @@ lcmp( '\\]{2,4}?', __LINE__ );
 lcmp( '\\|{2,4}?', __LINE__ );
 
 {
-    my $r = Regexp::Assemble->new;
-    is_deeply( Regexp::Assemble->new->_lex( '' ), [], '_lex empty string' );
+	my $r = Regexp::Assemble->new;
+	is_deeply( Regexp::Assemble->new->_lex( '' ), [], '_lex empty string' );
 
-    my $str = 'abc';
-    is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'a', 'b', 'c' ], "_lex $str",);
+	my $str = 'abc';
+	is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'a', 'b', 'c' ], "_lex $str",);
 
-    $str = 'a+b*c?';
-    is_deeply( Regexp::Assemble->new->_lex( $str ),
-        [ 'a+', 'b*', 'c?' ],
-        "_lex $str",
-    );
+	$str = 'a+b*c?';
+	is_deeply( Regexp::Assemble->new->_lex( $str ),
+		[ 'a+', 'b*', 'c?' ],
+		"_lex $str",
+	);
 
-    $str = '\e\t\cb\cs';
-    is_deeply( Regexp::Assemble->new->_lex( $str ),
-        [ '\e', '\t', '\cb', '\cs' ],
-        "_lex $str",
-    );
+	$str = '\e\t\cb\cs';
+	is_deeply( Regexp::Assemble->new->_lex( $str ),
+		[ '\e', '\t', '\cb', '\cs' ],
+		"_lex $str",
+	);
 
-    $str = 'a+\\d+';
-    is_deeply( Regexp::Assemble->new->_lex( $str ),
-        [ 'a+', '\\d+' ],
-        "_lex $str",
-    );
+	$str = 'a+\\d+';
+	is_deeply( Regexp::Assemble->new->_lex( $str ),
+		[ 'a+', '\\d+' ],
+		"_lex $str",
+	);
 
-    $str = 'a/b';
-    is_deeply( Regexp::Assemble->new->_lex( $str ),
-        [ 'a', '\\/', 'b' ],
-        "_lex $str",
-    );
+	$str = 'a/b';
+	is_deeply( Regexp::Assemble->new->_lex( $str ),
+		[ 'a', '\\/', 'b' ],
+		"_lex $str",
+	);
 
-    $str = 'a+?b*?c??';
-    is_deeply( Regexp::Assemble->new->_lex( $str ),
-        [ 'a+?', 'b*?', 'c??' ],
-        "_lex $str",
-    );
+	$str = 'a+?b*?c??';
+	is_deeply( Regexp::Assemble->new->_lex( $str ),
+		[ 'a+?', 'b*?', 'c??' ],
+		"_lex $str",
+	);
 
-    $str = 'abc[def]g';
-    is_deeply( Regexp::Assemble->new->_lex( $str ),
-        [ 'a', 'b', 'c', '[def]', 'g' ],
-        "_lex $str",
-    );
+	$str = 'abc[def]g';
+	is_deeply( Regexp::Assemble->new->_lex( $str ),
+		[ 'a', 'b', 'c', '[def]', 'g' ],
+		"_lex $str",
+	);
 
-    $str = '(?:ab)?c[def]+g';
-    is_deeply( Regexp::Assemble->new->_lex( $str ),
-        [ '(?:ab)?', 'c', '[def]+', 'g' ],
-        "_lex $str",
-    );
+	$str = '(?:ab)?c[def]+g';
+	is_deeply( Regexp::Assemble->new->_lex( $str ),
+		[ '(?:ab)?', 'c', '[def]+', 'g' ],
+		"_lex $str",
+	);
 
-    $str = '(?:ab)?c[def]{2,7}?g';
-    is_deeply( Regexp::Assemble->new->_lex( $str ),
-        [ '(?:ab)?', 'c', '[def]{2,7}?', 'g' ],
-        "_lex $str",
-    );
+	$str = '(?:ab)?c[def]{2,7}?g';
+	is_deeply( Regexp::Assemble->new->_lex( $str ),
+		[ '(?:ab)?', 'c', '[def]{2,7}?', 'g' ],
+		"_lex $str",
+	);
 
-    $str = 'abc[def]g(?:hi[jk]lm[no]p)';
-    is_deeply( Regexp::Assemble->new->_lex( $str ),
-        [ 'a', 'b', 'c', '[def]', 'g', '(?:hi[jk]lm[no]p)' ],
-        "_lex $str",
-    );
+	$str = 'abc[def]g(?:hi[jk]lm[no]p)';
+	is_deeply( Regexp::Assemble->new->_lex( $str ),
+		[ 'a', 'b', 'c', '[def]', 'g', '(?:hi[jk]lm[no]p)' ],
+		"_lex $str",
+	);
 
-    $str = 'abc[def]g[,.%\\]$&].\\.$';
-    is_deeply( Regexp::Assemble->new->_lex( $str ),
-        [ 'a', 'b', 'c', '[def]', 'g', '[,.%\\]$&]', '.', '\\.', '$' ],
-        "_lex $str",
-    );
+	$str = 'abc[def]g[,.%\\]$&].\\.$';
+	is_deeply( Regexp::Assemble->new->_lex( $str ),
+		[ 'a', 'b', 'c', '[def]', 'g', '[,.%\\]$&]', '.', '\\.', '$' ],
+		"_lex $str",
+	);
 
-    $str = 'abc[def]g[,.%\\]$&{]{2,4}.\\.$';
-    is_deeply( Regexp::Assemble->new->_lex( $str ),
-        [ 'a', 'b', 'c', '[def]', 'g', '[,.%\\]$&{]{2,4}', '.', '\\.', '$' ],
-        "_lex $str",
-    );
+	$str = 'abc[def]g[,.%\\]$&{]{2,4}.\\.$';
+	is_deeply( Regexp::Assemble->new->_lex( $str ),
+		[ 'a', 'b', 'c', '[def]', 'g', '[,.%\\]$&{]{2,4}', '.', '\\.', '$' ],
+		"_lex $str",
+	);
 
-    $str = '\\w+\\d{2,}\\s+?\\w{1,100}?\\cx*';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ),
-        [ '\\w+', '\\d{2,}', '\\s+?', '\\w{1,100}?', '\\cx*' ],
-        "_lex $str",
-    );
+	$str = '\\w+\\d{2,}\\s+?\\w{1,100}?\\cx*';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ),
+		[ '\\w+', '\\d{2,}', '\\s+?', '\\w{1,100}?', '\\cx*' ],
+		"_lex $str",
+	);
 
-    $str = '\\012+\\.?\\xae+\\x{dead}\\x{beef}+';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ),
-        [ '\\012+', '\\.?', '\\xae+', '\\x{dead}', '\\x{beef}+' ],
-        "_lex $str",
-    );
+	$str = '\\012+\\.?\\xae+\\x{dead}\\x{beef}+';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ),
+		[ '\\012+', '\\.?', '\\xae+', '\\x{dead}', '\\x{beef}+' ],
+		"_lex $str",
+	);
 
-    $str = '\\012+\\.?\\xae+\\x{dead}\\x{beef}{2,}';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ),
-        [ '\\012+', '\\.?', '\\xae+', '\\x{dead}', '\\x{beef}{2,}' ],
-        "_lex $str",
-    );
+	$str = '\\012+\\.?\\xae+\\x{dead}\\x{beef}{2,}';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ),
+		[ '\\012+', '\\.?', '\\xae+', '\\x{dead}', '\\x{beef}{2,}' ],
+		"_lex $str",
+	);
 
-    $str = '\\c[\\ca\\c]\\N{foo}';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ),
-        [ '\\c[', '\\ca', '\\c]', '\\N{foo}' ],
-        "_lex $str",
-    );
+	$str = '\\c[\\ca\\c]\\N{foo}';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ),
+		[ '\\c[', '\\ca', '\\c]', '\\N{foo}' ],
+		"_lex $str",
+	);
 
-    $str = '\\b(?:ab\(cd\)ef)+?(?:ab[cd]+e)*';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ),
-        [ '\\b', '(?:ab\(cd\)ef)+?', '(?:ab[cd]+e)*' ],
-        "_lex $str",
-    );
+	$str = '\\b(?:ab\(cd\)ef)+?(?:ab[cd]+e)*';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ),
+		[ '\\b', '(?:ab\(cd\)ef)+?', '(?:ab[cd]+e)*' ],
+		"_lex $str",
+	);
 
-    $str = '\\A[^bc\]\d]+\\Z';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ),
-        [ '\\A', '[^bc\]\d]+', '\\Z' ],
-        "_lex $str",
-    );
+	$str = '\\A[^bc\]\d]+\\Z';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ),
+		[ '\\A', '[^bc\]\d]+', '\\Z' ],
+		"_lex $str",
+	);
 
-    $str = 'a\\d+\\w*:[\\d\\s]+.z(?!foo)d';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ),
-        [ 'a', '\\d+', '\\w*', ':', '[\\d\\s]+', '.', 'z', '(?!foo)', 'd' ],
-        "_lex $str",
-    );
+	$str = 'a\\d+\\w*:[\\d\\s]+.z(?!foo)d';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ),
+		[ 'a', '\\d+', '\\w*', ':', '[\\d\\s]+', '.', 'z', '(?!foo)', 'd' ],
+		"_lex $str",
+	);
 
-    $str = '\Qa+b*\Ec?';
-    is_deeply( Regexp::Assemble->new->_lex( $str ),
-        [ 'a', '\+', 'b', '\*', 'c?' ],
-        "_lex $str",
-    );
+	$str = '\Qa+b*\Ec?';
+	is_deeply( Regexp::Assemble->new->_lex( $str ),
+		[ 'a', '\+', 'b', '\*', 'c?' ],
+		"_lex $str",
+	);
 
-    $str = 'a\\ub';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ),
-        [ 'a', 'B' ],
-        "_lex $str",
-    );
+	$str = 'a\\ub';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ),
+		[ 'a', 'B' ],
+		"_lex $str",
+	);
 
-    $str = 'A\\lB';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ),
-        [ 'A', 'b' ],
-        "_lex $str",
-    );
+	$str = 'A\\lB';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ),
+		[ 'A', 'b' ],
+		"_lex $str",
+	);
 
-    $str = '\\Qx*';
-    is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'x', '\\*' ], "_lex $str" );
+	$str = '\\Qx*';
+	is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'x', '\\*' ], "_lex $str" );
 
-    $str = 'a\\Q+x*\\Eb+';
-    is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'a', '\\+', 'x', '\\*', 'b+' ], "_lex $str" );
+	$str = 'a\\Q+x*\\Eb+';
+	is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'a', '\\+', 'x', '\\*', 'b+' ], "_lex $str" );
 
-    $str = 'a\\Q+x*b+';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ), [ 'a', '\\+', 'x', '\\*', 'b', '\\+' ], "_lex $str" );
+	$str = 'a\\Q+x*b+';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ), [ 'a', '\\+', 'x', '\\*', 'b', '\\+' ], "_lex $str" );
 
-    $str = 'a\\Q\\L\\Ez';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ), [ 'a', 'z' ], "_lex $str" );
+	$str = 'a\\Q\\L\\Ez';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ), [ 'a', 'z' ], "_lex $str" );
 
-    $str = 'a\\L\\Q\\Ez';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ), [ 'a', 'z' ], "_lex $str" );
+	$str = 'a\\L\\Q\\Ez';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ), [ 'a', 'z' ], "_lex $str" );
 
-    $str = 'a\\L\\Q\\U\\Ez';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ), [ 'a', 'z' ], "_lex $str" );
+	$str = 'a\\L\\Q\\U\\Ez';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ), [ 'a', 'z' ], "_lex $str" );
 
-    $str = 'a\\L\\Q\\Uz';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ), [ 'a', 'Z' ], "_lex $str" );
+	$str = 'a\\L\\Q\\Uz';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ), [ 'a', 'Z' ], "_lex $str" );
 
-    $str = 'a\\Eb';
-    is_deeply( Regexp::Assemble->new->_lex( $str  ), [ 'a', 'b', ], "_lex $str" );
+	$str = 'a\\Eb';
+	is_deeply( Regexp::Assemble->new->_lex( $str  ), [ 'a', 'b', ], "_lex $str" );
 
-    $str = 'a\\LBCD\\Ee';
-    is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'a', 'b', 'c', 'd', 'e' ], "_lex $str" );
+	$str = 'a\\LBCD\\Ee';
+	is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'a', 'b', 'c', 'd', 'e' ], "_lex $str" );
 
-    $str = 'f\\LGHI';
-    is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'f', 'g', 'h', 'i' ], "_lex $str" );
+	$str = 'f\\LGHI';
+	is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'f', 'g', 'h', 'i' ], "_lex $str" );
 
-    $str = 'a\\Ubcd\\Ee';
-    is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'a', 'B', 'C', 'D', 'e' ], "_lex $str" );
+	$str = 'a\\Ubcd\\Ee';
+	is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'a', 'B', 'C', 'D', 'e' ], "_lex $str" );
 
-    $str = 'a\\Ub/d\\Ee';
-    is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'a', 'B', '\\/', 'D', 'e' ], "_lex $str" );
+	$str = 'a\\Ub/d\\Ee';
+	is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'a', 'B', '\\/', 'D', 'e' ], "_lex $str" );
 
-    $str = 'f\\Ughi';
-    is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'f', 'G', 'H', 'I' ], "_lex $str" );
+	$str = 'f\\Ughi';
+	is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'f', 'G', 'H', 'I' ], "_lex $str" );
 
-    $str = 'f\\Ughi\\LMX';
-    is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'f', 'G', 'H', 'I', 'm', 'x' ], "_lex $str" );
+	$str = 'f\\Ughi\\LMX';
+	is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'f', 'G', 'H', 'I', 'm', 'x' ], "_lex $str" );
 
-    $str = 'f\\Ughi\\E\\LMX';
-    is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'f', 'G', 'H', 'I', 'm', 'x' ], "_lex $str" );
+	$str = 'f\\Ughi\\E\\LMX';
+	is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'f', 'G', 'H', 'I', 'm', 'x' ], "_lex $str" );
 
-    $str = 'f\\Ugh\\x20';
-    is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'f', 'G', 'H', ' ' ], "_lex $str" );
+	$str = 'f\\Ugh\\x20';
+	is_deeply( Regexp::Assemble->new->_lex( $str ), [ 'f', 'G', 'H', ' ' ], "_lex $str" );
 
-    $str = 'a\\Q+x*\\Eb+';
-    is_deeply( Regexp::Assemble->new->add( $str )->_path,
-        [ 'a', '\\+', 'x', '\\*', 'b+' ], "add $str" );
+	$str = 'a\\Q+x*\\Eb+';
+	is_deeply( Regexp::Assemble->new->add( $str )->_path,
+		[ 'a', '\\+', 'x', '\\*', 'b+' ], "add $str" );
 
-    $str = 'a\\Q+x*b+';
-    is_deeply( Regexp::Assemble->new->add( $str )->_path,
-        [ 'a', '\\+', 'x', '\\*', 'b', '\\+' ], "add $str" );
+	$str = 'a\\Q+x*b+';
+	is_deeply( Regexp::Assemble->new->add( $str )->_path,
+		[ 'a', '\\+', 'x', '\\*', 'b', '\\+' ], "add $str" );
 
-    my $out;
-    $str = 'X\\LK+L{2,4}M\\EY';
-    is_deeply( $out = Regexp::Assemble->new->add( $str )->_path,
-        [ 'X', 'k+', 'l{2,4}', 'm', 'Y' ], "add $str" ) or diag("@$out");
+	my $out;
+	$str = 'X\\LK+L{2,4}M\\EY';
+	is_deeply( $out = Regexp::Assemble->new->add( $str )->_path,
+		[ 'X', 'k+', 'l{2,4}', 'm', 'Y' ], "add $str" ) or diag("@$out");
 
-    $str = 'p\\Q\\L\\Eq';
-    is_deeply( $out = Regexp::Assemble->new->add( $str )->_path,
-        [ 'p', 'q' ], "add $str" ) or diag("@$out");
+	$str = 'p\\Q\\L\\Eq';
+	is_deeply( $out = Regexp::Assemble->new->add( $str )->_path,
+		[ 'p', 'q' ], "add $str" ) or diag("@$out");
 
-    $str = 'q\\U\\Qh{7,9}\\Ew';
-    is_deeply( Regexp::Assemble->new->add( $str )->_path,
-        [ 'q', 'H', '\{', '7', ',', '9', '\}', 'w' ], "add $str" );
+	$str = 'q\\U\\Qh{7,9}\\Ew';
+	is_deeply( Regexp::Assemble->new->add( $str )->_path,
+		[ 'q', 'H', '\{', '7', ',', '9', '\}', 'w' ], "add $str" );
 
-    $str = 'a\\Ubc\\ldef\\Eg';
-    is_deeply( Regexp::Assemble->new->add( $str )->_path,
-        [ 'a', 'B', 'C', 'd', 'E', 'F', 'g' ], "add $str" );
+	$str = 'a\\Ubc\\ldef\\Eg';
+	is_deeply( Regexp::Assemble->new->add( $str )->_path,
+		[ 'a', 'B', 'C', 'd', 'E', 'F', 'g' ], "add $str" );
 
-    $str = 'a\\LBL+\\uxy\\QZ+';
-    is_deeply( Regexp::Assemble->new->add( $str )->_path,
-        [ 'a', 'b', 'l+', 'X', 'y', 'z', '\+' ], "add $str" );
+	$str = 'a\\LBL+\\uxy\\QZ+';
+	is_deeply( Regexp::Assemble->new->add( $str )->_path,
+		[ 'a', 'b', 'l+', 'X', 'y', 'z', '\+' ], "add $str" );
 
-    $str = '\Q^a[b[';
-    is_deeply( Regexp::Assemble->new->add( $str )->_path,
-        [ '\\^', 'a', '\\[', 'b', '\\[' ], "add $str" );
+	$str = '\Q^a[b[';
+	is_deeply( Regexp::Assemble->new->add( $str )->_path,
+		[ '\\^', 'a', '\\[', 'b', '\\[' ], "add $str" );
 }
 
 {
-    my $path;
+	my $path;
 
-    $path = [];
-    is_deeply( $path, Regexp::Assemble::_path_copy($path),
-        '_path_copy([])' );
+	$path = [];
+	is_deeply( $path, Regexp::Assemble::_path_copy($path),
+		'_path_copy([])' );
 
-    $path = [0, qw[ab cd ef]];
-    is_deeply( $path, Regexp::Assemble::_path_copy($path),
-        '_path_copy(0 ab cd ef)' );
+	$path = [0, qw[ab cd ef]];
+	is_deeply( $path, Regexp::Assemble::_path_copy($path),
+		'_path_copy(0 ab cd ef)' );
 
-    $path = {};
-    is_deeply( $path, Regexp::Assemble::_node_copy($path),
-        '_node_copy({})' );
+	$path = {};
+	is_deeply( $path, Regexp::Assemble::_node_copy($path),
+		'_node_copy({})' );
 
-    $path = {'a' => [qw[a bb ccc]], 'b'=>[qw[b cc ddd]]};
-    is_deeply( $path, Regexp::Assemble::_node_copy($path),
-        '_node_copy({a,b})' );
+	$path = {'a' => [qw[a bb ccc]], 'b'=>[qw[b cc ddd]]};
+	is_deeply( $path, Regexp::Assemble::_node_copy($path),
+		'_node_copy({a,b})' );
 
-    $path = [
-        {'c'=>['c','d'],'e'=>['e','f']},
-        't',
-        {'d'=>['d','f'],'b'=>['b',0]},
-        { '' => undef, 'a' => ['a']},
-    ];
-    is_deeply( $path, Regexp::Assemble::_path_copy($path),
-        '_path_copy({c,e} t {d,b} {* a}' );
+	$path = [
+		{'c'=>['c','d'],'e'=>['e','f']},
+		't',
+		{'d'=>['d','f'],'b'=>['b',0]},
+		{ '' => undef, 'a' => ['a']},
+	];
+	is_deeply( $path, Regexp::Assemble::_path_copy($path),
+		'_path_copy({c,e} t {d,b} {* a}' );
 
-    $path = [
-        [0, 1, 2],
-        ['a','b','c'],
-        ['d',{'e'=>['e','f'],'g'=>['g','h']}],
-    ];
-    is_deeply( $path, Regexp::Assemble::_path_copy($path),
-        '_path_copy(ab cd ef {* a})' );
+	$path = [
+		[0, 1, 2],
+		['a','b','c'],
+		['d',{'e'=>['e','f'],'g'=>['g','h']}],
+	];
+	is_deeply( $path, Regexp::Assemble::_path_copy($path),
+		'_path_copy(ab cd ef {* a})' );
 }
 
 is_deeply( $rt->_path, [], 'path is empty' );
@@ -759,211 +759,211 @@ is_deeply( $rt->_path, [], 'path is empty' );
 my $context = { debug => 0, depth => 0 };
 
 is_deeply( Regexp::Assemble::_unrev_path(
-    [0, 1], $context),
-    [1, 0], 'path(0,1)' );
+	[0, 1], $context),
+	[1, 0], 'path(0,1)' );
 
 is_deeply( Regexp::Assemble::_unrev_path(
-    [qw[ ab cd ef ]], $context),
-    [qw[ ef cd ab ]], 'path(ab,cd,ef)' );
+	[qw[ ab cd ef ]], $context),
+	[qw[ ef cd ab ]], 'path(ab,cd,ef)' );
 
 is_deeply( Regexp::Assemble::_unrev_path( Regexp::Assemble::_unrev_path(
-    [qw[ ab cd ef ]], $context), $context),
-    [qw[ ab cd ef ]], 'path(ab,cd,ef) back' );
+	[qw[ ab cd ef ]], $context), $context),
+	[qw[ ab cd ef ]], 'path(ab,cd,ef) back' );
 
 is_deeply( Regexp::Assemble::_unrev_path(
-    [qw[ ab cd ef \\d+ \\D ghi jkl mno ]], $context),
-    [qw[ mno jkl ghi \\D \\d+ ef cd ab ]], 'path(ab cd...)' );
+	[qw[ ab cd ef \\d+ \\D ghi jkl mno ]], $context),
+	[qw[ mno jkl ghi \\D \\d+ ef cd ab ]], 'path(ab cd...)' );
 
 is_deeply( Regexp::Assemble::_unrev_path( Regexp::Assemble::_unrev_path(
-    [qw[ ab cd ef \\d+ \\D ghi jkl mno ]], $context), $context),
-    [qw[ ab cd ef \\d+ \\D ghi jkl mno ]], 'path(ab cd...) back' );
+	[qw[ ab cd ef \\d+ \\D ghi jkl mno ]], $context), $context),
+	[qw[ ab cd ef \\d+ \\D ghi jkl mno ]], 'path(ab cd...) back' );
 
 is_deeply( Regexp::Assemble::_unrev_node(
-    { 0 => [0, 1]}, $context),
-    { 1 => [1, 0]},
-    'node(0)' );
+	{ 0 => [0, 1]}, $context),
+	{ 1 => [1, 0]},
+	'node(0)' );
 
 is_deeply( Regexp::Assemble::_unrev_node(
-    { 0 => [0, 1], 2 => [2, 0]}, $context),
-    { 1 => [1, 0], 0 => [0, 2]},
-    'node(0,2)' );
+	{ 0 => [0, 1], 2 => [2, 0]}, $context),
+	{ 1 => [1, 0], 0 => [0, 2]},
+	'node(0,2)' );
 
 is_deeply( Regexp::Assemble::_unrev_node(
-    { '' => undef, a => [qw[a b]] }, $context),
-    { '' => undef, b => [qw[b a]] },
-    'node(*,a,b)' );
+	{ '' => undef, a => [qw[a b]] }, $context),
+	{ '' => undef, b => [qw[b a]] },
+	'node(*,a,b)' );
 
 is_deeply( Regexp::Assemble::_unrev_node(
-    { '' => undef, a => [qw[a b]], b => [qw[b c d e f g]] }, $context),
-    { '' => undef, b => [qw[b a]], g => [qw[g f e d c b]] },
-    'node(*a,b2)' );
+	{ '' => undef, a => [qw[a b]], b => [qw[b c d e f g]] }, $context),
+	{ '' => undef, b => [qw[b a]], g => [qw[g f e d c b]] },
+	'node(*a,b2)' );
 
 is_deeply( Regexp::Assemble::_unrev_path(
-    [{x => [qw[x 0]], '' => undef }], $context),
-    [{0 => [qw[0 x]], '' => undef }], 'node(* 0)' );
+	[{x => [qw[x 0]], '' => undef }], $context),
+	[{0 => [qw[0 x]], '' => undef }], 'node(* 0)' );
 
 is_deeply( Regexp::Assemble::_unrev_node(
-    { ab => [qw[ab bc]], bc => [qw[bc cd de ef fg gh]], ef => [qw[ef gh ij]] }, $context),
-    { bc => [qw[bc ab]], gh => [qw[gh fg ef de cd bc]], ij => [qw[ij gh ef]] },
-    'node(ab,bc,ef)' );
+	{ ab => [qw[ab bc]], bc => [qw[bc cd de ef fg gh]], ef => [qw[ef gh ij]] }, $context),
+	{ bc => [qw[bc ab]], gh => [qw[gh fg ef de cd bc]], ij => [qw[ij gh ef]] },
+	'node(ab,bc,ef)' );
 
 is_deeply( Regexp::Assemble::_unrev_node(
-    {''=>undef,b=>[[{b=>['b'],'b?'=>[{''=>undef,b=>['b']},'a']}],{''=>undef,c=>['c']}]}, $context),
-    {''=>undef,c=>[{''=>undef,c=>['c']},[{a=>['a',{''=>undef,b=>['b']}],b=>['b']}]]},
-    'node of (?:(?:ab?|b)c?)?' );
+	{''=>undef,b=>[[{b=>['b'],'b?'=>[{''=>undef,b=>['b']},'a']}],{''=>undef,c=>['c']}]}, $context),
+	{''=>undef,c=>[{''=>undef,c=>['c']},[{a=>['a',{''=>undef,b=>['b']}],b=>['b']}]]},
+	'node of (?:(?:ab?|b)c?)?' );
 
 is_deeply( Regexp::Assemble::_unrev_path(
-    [qw[a b], {c=>[qw[c d e]], f=>[qw[f g h]], i=>[qw[i j], {k => [qw[k l m]], n=>[qw[n o p]]}, 'x' ]}], $context),
-    [{e=>[qw[e d c]], h=>[qw[h g f]], x=>['x', {m=>[qw[m l k]], p=>[qw[p o n]]}, qw[j i]]}, qw[b a]],
-    'path(node(path))');
+	[qw[a b], {c=>[qw[c d e]], f=>[qw[f g h]], i=>[qw[i j], {k => [qw[k l m]], n=>[qw[n o p]]}, 'x' ]}], $context),
+	[{e=>[qw[e d c]], h=>[qw[h g f]], x=>['x', {m=>[qw[m l k]], p=>[qw[p o n]]}, qw[j i]]}, qw[b a]],
+	'path(node(path))');
 
 {
-    my $ra = Regexp::Assemble->new
-        ->add( 'refused' )
-        ->add( 'fused' )
-        ->add( 'used' );
-    $ra->_reduce;
+	my $ra = Regexp::Assemble->new
+		->add( 'refused' )
+		->add( 'fused' )
+		->add( 'used' );
+	$ra->_reduce;
 
-    ok( eq_set(
-        [keys %{Regexp::Assemble::_lookahead($ra->{path}[0])}],
-        ['f', 'r']),
-        '_lookahead refused/fused/used'
-    );
+	ok( eq_set(
+		[keys %{Regexp::Assemble::_lookahead($ra->{path}[0])}],
+		['f', 'r']),
+		'_lookahead refused/fused/used'
+	);
 
-    $ra->reset
-        ->add( 'refused' )
-        ->add( 'reamused' )
-        ->add( 'fused' )
-        ->add( 'amused' )
-        ->add( 'used' )
-        ->_reduce;
+	$ra->reset
+		->add( 'refused' )
+		->add( 'reamused' )
+		->add( 'fused' )
+		->add( 'amused' )
+		->add( 'used' )
+		->_reduce;
 
-    ok( eq_set(
-        [keys %{Regexp::Assemble::_lookahead($ra->{path}[0])}],
-        ['a', 'f', 'r']),
-        '_lookahead reamused/refused/amused/fused/used'
-    );
+	ok( eq_set(
+		[keys %{Regexp::Assemble::_lookahead($ra->{path}[0])}],
+		['a', 'f', 'r']),
+		'_lookahead reamused/refused/amused/fused/used'
+	);
 
-    $ra->reset
-        ->add( 'reran' )
-        ->add( 'ran' )
-        ->_reduce;
+	$ra->reset
+		->add( 'reran' )
+		->add( 'ran' )
+		->_reduce;
 
-    ok( eq_set(
-        [keys %{Regexp::Assemble::_lookahead($ra->{path}[0])}],
-        ['r']),
-        '_lookahead reran/ran'
-    );
+	ok( eq_set(
+		[keys %{Regexp::Assemble::_lookahead($ra->{path}[0])}],
+		['r']),
+		'_lookahead reran/ran'
+	);
 
-    $ra->reset
-        ->add( 'cruised' )
-        ->add( 'bruised' )
-        ->add( 'hosed' )
-        ->add( 'gazed' )
-        ->add( 'used' )
-        ->_reduce;
+	$ra->reset
+		->add( 'cruised' )
+		->add( 'bruised' )
+		->add( 'hosed' )
+		->add( 'gazed' )
+		->add( 'used' )
+		->_reduce;
 
-    ok( eq_set(
-        [keys %{Regexp::Assemble::_lookahead($ra->{path}[0])}],
-        ['b', 'c', 'g', 'h', 'u']),
-        '_lookahead cruised/bruised/hosed/gazed/used'
-    );
+	ok( eq_set(
+		[keys %{Regexp::Assemble::_lookahead($ra->{path}[0])}],
+		['b', 'c', 'g', 'h', 'u']),
+		'_lookahead cruised/bruised/hosed/gazed/used'
+	);
 }
 
 is( Regexp::Assemble::_dump( [1, 0, undef] ),
-    '[1 0 *]', 'dump undef'
+	'[1 0 *]', 'dump undef'
 );
 
 is( Regexp::Assemble::_dump( [1, 0, q{ }] ),
-    q{[1 0 ' ']}, 'dump space'
+	q{[1 0 ' ']}, 'dump space'
 );
 
 is( Regexp::Assemble::_dump( {a => ['a', 'b'], b => ['b']} ),
-    '{a=>[a b] b=>[b]}', 'dump node'
+	'{a=>[a b] b=>[b]}', 'dump node'
 );
 
 is( Regexp::Assemble::_dump( ['a', chr(7), 'b'] ),
-    '[a \\x07 b]', 'dump pretty'
+	'[a \\x07 b]', 'dump pretty'
 );
 
 is( Regexp::Assemble->new->insert(qw( ))->insert(qw( ))->dump,
-    '[\\x07 {\\x05=>[\\x05] \\x06=>[\\x06]}]', 'dump pretty node'
+	'[\\x07 {\\x05=>[\\x05] \\x06=>[\\x06]}]', 'dump pretty node'
 );
 
 is( Regexp::Assemble::_dump( ['a', chr(7), 'b'] ),
-    '[a \\x07 b]', 'dump pretty'
+	'[a \\x07 b]', 'dump pretty'
 );
 
 is( Regexp::Assemble::_combine($stub, '?=', qw/ c a b / ),
-    '(?=[abc])', '_combine c a b'
+	'(?=[abc])', '_combine c a b'
 );
 
 is( Regexp::Assemble::_combine($stub, '?=', qw/ c ab de / ),
-    '(?=ab|de|c)', '_combine c ab de'
+	'(?=ab|de|c)', '_combine c ab de'
 );
 
 is( Regexp::Assemble::_combine($stub, '?=', qw/ in og / ),
-    '(?=in|og)', '_combine in og'
+	'(?=in|og)', '_combine in og'
 );
 
 is( Regexp::Assemble::_combine($stub, '?=', qw/ in og j k l / ),
-    '(?=[jkl]|in|og)', '_combine in og j k l'
+	'(?=[jkl]|in|og)', '_combine in og j k l'
 );
 
 is( Regexp::Assemble::_combine($stub, '?=', qw/ in og 0 1 2 3 4 5 6 7 8 9 / ),
-    '(?=\d|in|og)', '_combine in og 0 1 ... 9'
+	'(?=\d|in|og)', '_combine in og 0 1 ... 9'
 );
 
 is_deeply( Regexp::Assemble::_unrev_path(
-    [{x1     => ['x1', 'z\\d'], '' => undef }], $context),
-    [{'z\\d' => ['z\\d', 'x1'], '' => undef }], 'node(* metachar)' );
+	[{x1     => ['x1', 'z\\d'], '' => undef }], $context),
+	[{'z\\d' => ['z\\d', 'x1'], '' => undef }], 'node(* metachar)' );
 
 is_deeply( Regexp::Assemble::_unrev_path(
-    [{x     => ['x', '\\d'], '' => undef }], $context),
-    [{'\\d' => ['\\d', 'x'], '' => undef }], 'node(* metachar) 2' );
+	[{x     => ['x', '\\d'], '' => undef }], $context),
+	[{'\\d' => ['\\d', 'x'], '' => undef }], 'node(* metachar) 2' );
 
 is_deeply( Regexp::Assemble::_unrev_path(
-    [qw[ ab cd ef ], {x1 => ['x1', 'y2', 'z\\d'], mx => [qw[mx us ca]] }], $context),
-    [{ 'z\\d' => ['z\\d', 'y2', 'x1'], ca => [qw[ca us mx]]}, qw[ef cd ab]], 'path(node)' );
+	[qw[ ab cd ef ], {x1 => ['x1', 'y2', 'z\\d'], mx => [qw[mx us ca]] }], $context),
+	[{ 'z\\d' => ['z\\d', 'y2', 'x1'], ca => [qw[ca us mx]]}, qw[ef cd ab]], 'path(node)' );
 
 {
-    my $r = Regexp::Assemble->new;
+	my $r = Regexp::Assemble->new;
 
-    is_deeply( $r->lexstr( 'ab' ), ['a', 'b'], q{lexstr('ab')} );
-    is_deeply( $r->lexstr( 'a\\,b' ), ['a', ',', 'b'], q{lexstr('a\\,b')} );
+	is_deeply( $r->lexstr( 'ab' ), ['a', 'b'], q{lexstr('ab')} );
+	is_deeply( $r->lexstr( 'a\\,b' ), ['a', ',', 'b'], q{lexstr('a\\,b')} );
 }
 
 eval {
-    my $ra = Regexp::Assemble->new;
-    $ra->Default_Lexer( qr/\d+/ );
+	my $ra = Regexp::Assemble->new;
+	$ra->Default_Lexer( qr/\d+/ );
 };
 
 like( $@,
-    qr/^Cannot pass a Regexp::Assemble to Default_Lexer at \S+ line \d+/m,
-    'Default_Lexer die'
+	qr/^Cannot pass a Regexp::Assemble to Default_Lexer at \S+ line \d+/m,
+	'Default_Lexer die'
 );
 
 is_deeply( Regexp::Assemble->new->_fastlex('ab+c{2,4}'),
-    ['a', 'b+', 'c{2,4}'],
-    '_fastlex reg plus min-max'
+	['a', 'b+', 'c{2,4}'],
+	'_fastlex reg plus min-max'
 );
 
 my $x;
 is_deeply( $x = Regexp::Assemble->new->_fastlex('\\d+\\s{3,4}?\\Qa+\\E\\lL\\uu\\Ufoo\\E\\Lbar\\x40'),
-    ['\\d+', '\\s{3,4}?', 'a', '\\+', qw(l U F O O b a r @)],
-    '_fastlex backslash'
+	['\\d+', '\\s{3,4}?', 'a', '\\+', qw(l U F O O b a r @)],
+	'_fastlex backslash'
 ) or diag("@$x");
 
 is_deeply( $x = Regexp::Assemble->new->_fastlex('\\Q\\L\\Ua+\\E\\Ub?\\Ec'),
-    [qw(a \\+ B? c)], '_fastlex in and out of quotemeta'
+	[qw(a \\+ B? c)], '_fastlex in and out of quotemeta'
 ) or diag("@$x");
 
 is_deeply( $x = Regexp::Assemble->new->_fastlex('\\A\\a\\e\\f\\r\\n\\t\\Z'),
-    [qw(\\A \\a \\e \\f \\r \\n \\t \\Z)], '_fastlex backslash letter'
+	[qw(\\A \\a \\e \\f \\r \\n \\t \\Z)], '_fastlex backslash letter'
 ) or diag("@$x");
 
 is_deeply( $x = Regexp::Assemble->new->_fastlex('\\cG\\cd\\007*?\\041\\z'),
-    [qw(\\cG \\cD \\cG*? ! \\z)], '_fastlex backslash misc'
+	[qw(\\cG \\cD \\cG*? ! \\z)], '_fastlex backslash misc'
 ) or diag("@$x");
 
 package Regexp::Assemble;
@@ -975,4 +975,3 @@ is_deeply( [@list], [@out], 'bogus coverage improvements rulez' );
 
 
 is( $_, $fixed, '$_ has not been altered' );
-

--- a/t/01_insert.t
+++ b/t/01_insert.t
@@ -4,7 +4,7 @@
 #
 # When a series of paths are inserted in an R::A object, they are
 # stored into tree structure using a crafty blend of arrays and hashes.
-# 
+#
 # These tests verify that the tokens that are added to the
 # Regexp::Assemble object are stored correctly.
 #
@@ -21,577 +21,577 @@ use constant permute_testcount => 120 * 5; # permute() has 120 (5!) variants
 
 eval qq{use Test::More tests => 50 + permute_testcount};
 if( $@ ) {
-    warn "# Test::More not available, no tests performed\n";
-    print "1..1\nok 1\n";
-    exit 0;
+	warn "# Test::More not available, no tests performed\n";
+	print "1..1\nok 1\n";
+	exit 0;
 }
 
 my $fixed = 'The scalar remains the same';
 $_ = $fixed;
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( '' );
-    my $r = ($ra->_path)->[0];
-    is( ref($r), 'HASH',  q{insert('') => first element is a HASH} );
-    is( scalar(keys %$r), 1,      q{...and contains one key} );
-    ok( exists $r->{''},    q{...which is an empty string} );
-    ok( !defined($r->{''}), q{...and points to undef} );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( '' );
+	my $r = ($ra->_path)->[0];
+	is( ref($r), 'HASH',  q{insert('') => first element is a HASH} );
+	is( scalar(keys %$r), 1,      q{...and contains one key} );
+	ok( exists $r->{''},    q{...which is an empty string} );
+	ok( !defined($r->{''}), q{...and points to undef} );
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( 'a' );
-    my $r = $ra->_path;
-    is( scalar @$r, 1,  q{'a' => path of length 1} );
-    is( $r->[0], 'a',   q{'a' => ...and is an 'a'} );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( 'a' );
+	my $r = $ra->_path;
+	is( scalar @$r, 1,  q{'a' => path of length 1} );
+	is( $r->[0], 'a',   q{'a' => ...and is an 'a'} );
 }
 
 {
-    my $r = Regexp::Assemble->new;
-    $r->insert();
-    $r->insert('a');
-    is_deeply( $r->_path, [{'' => undef, 'a' => ['a']}], q{insert(), insert('a')} );
+	my $r = Regexp::Assemble->new;
+	$r->insert();
+	$r->insert('a');
+	is_deeply( $r->_path, [{'' => undef, 'a' => ['a']}], q{insert(), insert('a')} );
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( 'a', 'b' );
-    my $r = $ra->_path;
-    is( scalar @$r, 2,  q{'ab' => path of length 2} );
-    is( join( '' => @$r ), 'ab', q{'ab' => ...and is 'a', 'b'} );
-    is( $ra->dump, '[a b]', 'dump([a b])' );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( 'a', 'b' );
+	my $r = $ra->_path;
+	is( scalar @$r, 2,  q{'ab' => path of length 2} );
+	is( join( '' => @$r ), 'ab', q{'ab' => ...and is 'a', 'b'} );
+	is( $ra->dump, '[a b]', 'dump([a b])' );
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( 'a', 'b' );
-    $ra->insert( 'a', 'c' );
-    is( $ra->dump, '[a {b=>[b] c=>[c]}]', 'dump([a {b c}])' );
-    my $r = $ra->_path;
-    is( scalar @$r, 2,        q{'ab,ac' => path of length 2} );
-    is( $r->[0], 'a',         q{'ab,ac' => ...and first atom is 'a'} );
-    is( ref($r->[1]), 'HASH', q{'ab,ac' => ...and second is a node} );
-    $r = $r->[1];
-    is( scalar(keys %$r), 2,  q{'ab,ac' => ...node has two keys} );
-    is( join( '' => sort keys %$r ), 'bc',
-        q{'ab,ac' => ...keys are 'b','c'} );
-    ok( exists $r->{b}, q{'ab,ac' => ... key 'b' exists} );
-    is( ref($r->{b}), 'ARRAY', q{'ab,ac' => ... and points to a path} );
-    ok( exists $r->{c}, q{'ab,ac' => ... key 'c' exists} );
-    is( ref($r->{c}), 'ARRAY', q{'ab,ac' => ... and points to a path} );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( 'a', 'b' );
+	$ra->insert( 'a', 'c' );
+	is( $ra->dump, '[a {b=>[b] c=>[c]}]', 'dump([a {b c}])' );
+	my $r = $ra->_path;
+	is( scalar @$r, 2,        q{'ab,ac' => path of length 2} );
+	is( $r->[0], 'a',         q{'ab,ac' => ...and first atom is 'a'} );
+	is( ref($r->[1]), 'HASH', q{'ab,ac' => ...and second is a node} );
+	$r = $r->[1];
+	is( scalar(keys %$r), 2,  q{'ab,ac' => ...node has two keys} );
+	is( join( '' => sort keys %$r ), 'bc',
+		q{'ab,ac' => ...keys are 'b','c'} );
+	ok( exists $r->{b}, q{'ab,ac' => ... key 'b' exists} );
+	is( ref($r->{b}), 'ARRAY', q{'ab,ac' => ... and points to a path} );
+	ok( exists $r->{c}, q{'ab,ac' => ... key 'c' exists} );
+	is( ref($r->{c}), 'ARRAY', q{'ab,ac' => ... and points to a path} );
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( undef );
-    is_deeply( $ra->_path, [{'' => undef}], 'insert(undef)' );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( undef );
+	is_deeply( $ra->_path, [{'' => undef}], 'insert(undef)' );
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( '' );
-    is_deeply( $ra->_path, [{'' => undef}], q{insert('')} );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( '' );
+	is_deeply( $ra->_path, [{'' => undef}], q{insert('')} );
 }
 
 {
-    my $r = Regexp::Assemble->new;
-    $r->insert();
-    is_deeply( $r->_path, [{'' => undef}], 'insert()' );
+	my $r = Regexp::Assemble->new;
+	$r->insert();
+	is_deeply( $r->_path, [{'' => undef}], 'insert()' );
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( '0' );
-    is_deeply( $ra->_path,
-        [0],
-        q{/0/},
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( '0' );
+	is_deeply( $ra->_path,
+		[0],
+		q{/0/},
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( qw/d/ );
-    is_deeply( $ra->_path,
-        ['d'],
-        '/d/',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( qw/d/ );
+	is_deeply( $ra->_path,
+		['d'],
+		'/d/',
+	);
 }
 
 {
-    my $r = Regexp::Assemble->new->lex( '\([^(]*(?:\([^)]*\))?[^)]*\)|.' );
+	my $r = Regexp::Assemble->new->lex( '\([^(]*(?:\([^)]*\))?[^)]*\)|.' );
 
-    $r->reset->add( 'ab(cd)ef' );
-    is_deeply( $r->_path,
-        [ 'a', 'b', '(cd)', 'e', 'f' ],
-        'ab(cd)ef (with parenthetical lexer)'
-    );
+	$r->reset->add( 'ab(cd)ef' );
+	is_deeply( $r->_path,
+		[ 'a', 'b', '(cd)', 'e', 'f' ],
+		'ab(cd)ef (with parenthetical lexer)'
+	);
 
-    $r->reset->add( 'ab(cd(ef)gh)ij' );
-    is_deeply( $r->_path,
-        [ 'a', 'b', '(cd(ef)gh)', 'i', 'j' ],
-        'ab(cd(ef)gh)ij (with parenthetical lexer)'
-    );
+	$r->reset->add( 'ab(cd(ef)gh)ij' );
+	is_deeply( $r->_path,
+		[ 'a', 'b', '(cd(ef)gh)', 'i', 'j' ],
+		'ab(cd(ef)gh)ij (with parenthetical lexer)'
+	);
 
-    $r->reset->add( 'ab((ef)gh)ij' );
-    is_deeply( $r->_path,
-        [ 'a', 'b', '((ef)gh)', 'i', 'j' ],
-        'ab((ef)gh)ij (with parenthetical lexer)'
-    );
+	$r->reset->add( 'ab((ef)gh)ij' );
+	is_deeply( $r->_path,
+		[ 'a', 'b', '((ef)gh)', 'i', 'j' ],
+		'ab((ef)gh)ij (with parenthetical lexer)'
+	);
 
-    $r->reset->add( 'ab(cd(ef))ij' );
-    is_deeply( $r->_path,
-        [ 'a', 'b', '(cd(ef))', 'i', 'j' ],
-        'ab(cd(ef))ij (with parenthetical lexer)'
-    );
+	$r->reset->add( 'ab(cd(ef))ij' );
+	is_deeply( $r->_path,
+		[ 'a', 'b', '(cd(ef))', 'i', 'j' ],
+		'ab(cd(ef))ij (with parenthetical lexer)'
+	);
 
-    $r->reset->add( 'ab((ef))ij' );
-    is_deeply( $r->_path,
-        [ 'a', 'b', '((ef))', 'i', 'j' ],
-        'ab((ef))ij (with parenthetical lexer)'
-    );
+	$r->reset->add( 'ab((ef))ij' );
+	is_deeply( $r->_path,
+		[ 'a', 'b', '((ef))', 'i', 'j' ],
+		'ab((ef))ij (with parenthetical lexer)'
+	);
 }
 
 {
-    my $r = Regexp::Assemble->new(lex => '\\d');
-    is_deeply( $r->add( '0\Q0C,+' )->_path,
-        [ '0', '0', 'C', ',', '\\+' ],
-        '0\\Q0C,+ with \\d lexer',
-    );
+	my $r = Regexp::Assemble->new(lex => '\\d');
+	is_deeply( $r->add( '0\Q0C,+' )->_path,
+		[ '0', '0', 'C', ',', '\\+' ],
+		'0\\Q0C,+ with \\d lexer',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( qw/d a b/ );
-    is_deeply( $ra->_path,
-        [qw/d a b/],
-        '/dab/',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( qw/d a b/ );
+	is_deeply( $ra->_path,
+		[qw/d a b/],
+		'/dab/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( qw/0 1/ );
-    $ra->insert( qw/0 2/ );
-    is_deeply( $ra->_path,
-        [
-            '0',
-            {
-                '1' => ['1'],
-                '2' => ['2'],
-            },
-        ],
-        '/01/ /02/',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( qw/0 1/ );
+	$ra->insert( qw/0 2/ );
+	is_deeply( $ra->_path,
+		[
+			'0',
+			{
+				'1' => ['1'],
+				'2' => ['2'],
+			},
+		],
+		'/01/ /02/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( qw/0/ );
-    $ra->insert( qw/0 1/ );
-    $ra->insert( qw/0 2/ );
-    is_deeply( $ra->_path,
-        [
-            '0',
-            {
-                '1' => ['1'],
-                '2' => ['2'],
-                ''  => undef,
-            },
-        ],
-        '/0/ /01/ /02/',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( qw/0/ );
+	$ra->insert( qw/0 1/ );
+	$ra->insert( qw/0 2/ );
+	is_deeply( $ra->_path,
+		[
+			'0',
+			{
+				'1' => ['1'],
+				'2' => ['2'],
+				''  => undef,
+			},
+		],
+		'/0/ /01/ /02/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( qw/d a m/ );
-    $ra->insert( qw/d a m/ );
-    is_deeply( $ra->_path,
-        [
-            'd', 'a', 'm',
-        ],
-        '/dam/ x 2',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( qw/d a m/ );
+	$ra->insert( qw/d a m/ );
+	is_deeply( $ra->_path,
+		[
+			'd', 'a', 'm',
+		],
+		'/dam/ x 2',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( qw/d a y/ );
-    $ra->insert( qw/d a/ );
-    $ra->insert( qw/d a/ );
-    is_deeply( $ra->_path,
-        [
-            'd', 'a',
-            {
-                'y' => ['y'],
-                ''  => undef,
-            },
-        ],
-        '/day/, /da/ x 2',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( qw/d a y/ );
+	$ra->insert( qw/d a/ );
+	$ra->insert( qw/d a/ );
+	is_deeply( $ra->_path,
+		[
+			'd', 'a',
+			{
+				'y' => ['y'],
+				''  => undef,
+			},
+		],
+		'/day/, /da/ x 2',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( qw/d o t/ );
-    $ra->insert( qw/d o/ );
-    $ra->insert( qw/d/ );
-    is_deeply( $ra->_path,
-        [
-            'd',
-            {
-                'o' => [
-                    'o',
-                    {
-                        't' => ['t'],
-                        ''  => undef,
-                    },
-                ],
-                '' => undef,
-            },
-        ],
-        '/dot/ /do/ /d/',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( qw/d o t/ );
+	$ra->insert( qw/d o/ );
+	$ra->insert( qw/d/ );
+	is_deeply( $ra->_path,
+		[
+			'd',
+			{
+				'o' => [
+					'o',
+					{
+						't' => ['t'],
+						''  => undef,
+					},
+				],
+				'' => undef,
+			},
+		],
+		'/dot/ /do/ /d/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( qw/b i g/ );
-    $ra->insert( qw/b i d/ );
-    is_deeply( $ra->_path,
-        [
-            'b', 'i',
-            {
-                'd' => ['d'],
-                'g' => ['g'],
-            },
-        ],
-        '/big/ /bid/',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( qw/b i g/ );
+	$ra->insert( qw/b i d/ );
+	is_deeply( $ra->_path,
+		[
+			'b', 'i',
+			{
+				'd' => ['d'],
+				'g' => ['g'],
+			},
+		],
+		'/big/ /bid/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( qw/d a r t/ );
-    $ra->insert( qw/d a m p/ );
-    is_deeply( $ra->_path,
-        [
-            'd', 'a',
-            {
-                'r' => ['r', 't'],
-                'm' => ['m', 'p'],
-            },
-        ],
-        '/dart/ /damp/',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( qw/d a r t/ );
+	$ra->insert( qw/d a m p/ );
+	is_deeply( $ra->_path,
+		[
+			'd', 'a',
+			{
+				'r' => ['r', 't'],
+				'm' => ['m', 'p'],
+			},
+		],
+		'/dart/ /damp/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( qw/a m b l e/ );
-    $ra->insert( qw/i d l e/ );
-    is_deeply( $ra->_path,
-        [
-            {
-                'a' => ['a', 'm', 'b', 'l', 'e'],
-                'i' => ['i', 'd', 'l', 'e'],
-            },
-        ],
-        '/amble/ /idle/',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( qw/a m b l e/ );
+	$ra->insert( qw/i d l e/ );
+	is_deeply( $ra->_path,
+		[
+			{
+				'a' => ['a', 'm', 'b', 'l', 'e'],
+				'i' => ['i', 'd', 'l', 'e'],
+			},
+		],
+		'/amble/ /idle/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( qw/a m b l e/ );
-    $ra->insert( qw/a m p l e/ );
-    $ra->insert( qw/i d l e/ );
-    is_deeply( $ra->_path,
-        [
-            {
-                'a' => [
-                    'a', 'm',
-                    {
-                        'b' => [ 'b', 'l', 'e' ],
-                        'p' => [ 'p', 'l', 'e' ],
-                    },
-                ],
-                'i' => ['i', 'd', 'l', 'e'],
-            },
-        ],
-        '/amble/ /ample/ /idle/',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( qw/a m b l e/ );
+	$ra->insert( qw/a m p l e/ );
+	$ra->insert( qw/i d l e/ );
+	is_deeply( $ra->_path,
+		[
+			{
+				'a' => [
+					'a', 'm',
+					{
+						'b' => [ 'b', 'l', 'e' ],
+						'p' => [ 'p', 'l', 'e' ],
+					},
+				],
+				'i' => ['i', 'd', 'l', 'e'],
+			},
+		],
+		'/amble/ /ample/ /idle/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( qw/d a m/ );
-    $ra->insert( qw/d a r e/ );
-    is_deeply( $ra->_path,
-        [
-            'd', 'a',
-            {
-                'm' => ['m'],
-                'r' => ['r', 'e'],
-                    ,
-            },
-        ],
-        '/dam/ /dare/',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( qw/d a m/ );
+	$ra->insert( qw/d a r e/ );
+	is_deeply( $ra->_path,
+		[
+			'd', 'a',
+			{
+				'm' => ['m'],
+				'r' => ['r', 'e'],
+					,
+			},
+		],
+		'/dam/ /dare/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert(qw/d a/)
-        ->insert(qw/d b/)
-        ->insert(qw/d c/)
-    ;
-    is_deeply( $ra->_path,
-        [
-            'd',
-            {
-                'a' => ['a'],
-                'b' => ['b'],
-                'c' => ['c'],
-            },
-        ],
-        '/da/ /db/ /dc/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert(qw/d a/)
+		->insert(qw/d b/)
+		->insert(qw/d c/)
+	;
+	is_deeply( $ra->_path,
+		[
+			'd',
+			{
+				'a' => ['a'],
+				'b' => ['b'],
+				'c' => ['c'],
+			},
+		],
+		'/da/ /db/ /dc/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert(qw/d a/)
-        ->insert(qw/d b c d/)
-        ->insert(qw/d c/)
-    ;
-    is_deeply( $ra->_path,
-        [
-            'd',
-            {
-                'a' => ['a'],
-                'b' => ['b', 'c', 'd'],
-                'c' => ['c'],
-            },
-        ],
-        '/da/ /dbcd/ /dc/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert(qw/d a/)
+		->insert(qw/d b c d/)
+		->insert(qw/d c/)
+	;
+	is_deeply( $ra->_path,
+		[
+			'd',
+			{
+				'a' => ['a'],
+				'b' => ['b', 'c', 'd'],
+				'c' => ['c'],
+			},
+		],
+		'/da/ /dbcd/ /dc/',
+	);
 }
 
 sub permute {
-    my $target = shift;
-    my $path   = shift;
-    my( $x1, $x2, $x3, $x4, $x5 );
-    for $x1( 0..4 ) {
-        for $x2( 0..4 ) {
-            next if $x2 == $x1;
-            for $x3( 0..4 ) {
-                next if grep { $_ == $x3 } ($x1, $x2);
-                for $x4( 0..4 ) {
-                    next if grep { $_ == $x4 } ($x1, $x2, $x3);
-                    for $x5( 0..4 ) {
-                        next if grep { $_ == $x5 } ($x1, $x2, $x3, $x4);
-                        my $ra = Regexp::Assemble->new
-                            ->insert( @{$path->[$x1]} )
-                            ->insert( @{$path->[$x2]} )
-                            ->insert( @{$path->[$x3]} )
-                            ->insert( @{$path->[$x4]} )
-                            ->insert( @{$path->[$x5]} )
-                        ;
-                        is_deeply( $ra->_path, $target,
-                            '/' . join( '/ /', 
-                                join( '' => @{$path->[$x1]}),
-                                join( '' => @{$path->[$x2]}),
-                                join( '' => @{$path->[$x3]}),
-                                join( '' => @{$path->[$x4]}),
-                                join( '' => @{$path->[$x5]}),
-                            ) . '/'
-                        ) or diag(
-                            $ra->dump(),
-                            ' versus ',
-                            Regexp::Assemble->_dump($target),
-                            "\n",
-                        );
-                    }
-                }
-            }
-        }
-    }
+	my $target = shift;
+	my $path   = shift;
+	my( $x1, $x2, $x3, $x4, $x5 );
+	for $x1( 0..4 ) {
+		for $x2( 0..4 ) {
+			next if $x2 == $x1;
+			for $x3( 0..4 ) {
+				next if grep { $_ == $x3 } ($x1, $x2);
+				for $x4( 0..4 ) {
+					next if grep { $_ == $x4 } ($x1, $x2, $x3);
+					for $x5( 0..4 ) {
+						next if grep { $_ == $x5 } ($x1, $x2, $x3, $x4);
+						my $ra = Regexp::Assemble->new
+							->insert( @{$path->[$x1]} )
+							->insert( @{$path->[$x2]} )
+							->insert( @{$path->[$x3]} )
+							->insert( @{$path->[$x4]} )
+							->insert( @{$path->[$x5]} )
+						;
+						is_deeply( $ra->_path, $target,
+							'/' . join( '/ /',
+								join( '' => @{$path->[$x1]}),
+								join( '' => @{$path->[$x2]}),
+								join( '' => @{$path->[$x3]}),
+								join( '' => @{$path->[$x4]}),
+								join( '' => @{$path->[$x5]}),
+							) . '/'
+						) or diag(
+							$ra->dump(),
+							' versus ',
+							Regexp::Assemble->_dump($target),
+							"\n",
+						);
+					}
+				}
+			}
+		}
+	}
 }
 
 permute(
-    [
-        'a', {
-            '' => undef, 'b' => [
-                'b', {
-                    '' => undef, 'c' => [
-                        'c', {
-                            '' => undef, 'd' => [
-                                'd', {
-                                    '' => undef, 'e' => [
-                                        'e',
-                                    ],
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ],
-        },
-    ],
-    [
-        [ 'a',                    ],
-        [ 'a', 'b'                ],
-        [ 'a', 'b', 'c'           ],
-        [ 'a', 'b', 'c', 'd'      ],
-        [ 'a', 'b', 'c', 'd', 'e' ],
-    ]
+	[
+		'a', {
+			'' => undef, 'b' => [
+				'b', {
+					'' => undef, 'c' => [
+						'c', {
+							'' => undef, 'd' => [
+								'd', {
+									'' => undef, 'e' => [
+										'e',
+									],
+								},
+							],
+						},
+					],
+				},
+			],
+		},
+	],
+	[
+		[ 'a',                    ],
+		[ 'a', 'b'                ],
+		[ 'a', 'b', 'c'           ],
+		[ 'a', 'b', 'c', 'd'      ],
+		[ 'a', 'b', 'c', 'd', 'e' ],
+	]
 );
 
 permute(
-    [
-        {
-            '' => undef, 'a' => [
-                'a', {
-                    '' => undef, 'b' => [
-                        'b', {
-                            '' => undef, 'c' => [
-                                'c', {
-                                    '' => undef, 'd' => [
-                                        'd',
-                                    ],
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ],
-        },
-    ],
-    [
-        [ '',                ],
-        [ 'a',               ],
-        [ 'a', 'b'           ],
-        [ 'a', 'b', 'c'      ],
-        [ 'a', 'b', 'c', 'd' ],
-    ]
+	[
+		{
+			'' => undef, 'a' => [
+				'a', {
+					'' => undef, 'b' => [
+						'b', {
+							'' => undef, 'c' => [
+								'c', {
+									'' => undef, 'd' => [
+										'd',
+									],
+								},
+							],
+						},
+					],
+				},
+			],
+		},
+	],
+	[
+		[ '',                ],
+		[ 'a',               ],
+		[ 'a', 'b'           ],
+		[ 'a', 'b', 'c'      ],
+		[ 'a', 'b', 'c', 'd' ],
+	]
 );
 
 permute(
-    [ 'd', 'o',
-    {
-        'n' => [
-            'n', 'a', 't',
-            {
-                'e' => ['e'],
-                'i' => ['i', 'o', 'n'],
-            },
-        ]
-        ,
-        't' => [
-            't',
-            {
-                'a' => ['a', 't', 'e'],
-                'i' => ['i', 'n', 'g'],
-            },
-        ],
-        ,
-        '' => undef,
-    }],
-    [
-        [ split //, 'do'       ],
-        [ split //, 'donate'   ],
-        [ split //, 'donation' ],
-        [ split //, 'dotate'   ],
-        [ split //, 'doting'   ],
-    ]
+	[ 'd', 'o',
+	{
+		'n' => [
+			'n', 'a', 't',
+			{
+				'e' => ['e'],
+				'i' => ['i', 'o', 'n'],
+			},
+		]
+		,
+		't' => [
+			't',
+			{
+				'a' => ['a', 't', 'e'],
+				'i' => ['i', 'n', 'g'],
+			},
+		],
+		,
+		'' => undef,
+	}],
+	[
+		[ split //, 'do'       ],
+		[ split //, 'donate'   ],
+		[ split //, 'donation' ],
+		[ split //, 'dotate'   ],
+		[ split //, 'doting'   ],
+	]
 );
 
 permute(
-    [
-        'o',
-        {
-            ''  => undef,
-            'n' => [
-                'n', {
-                    ''  => undef,
-                    'l' => ['l', 'y'],
-                    'e' => [
-                        'e', {
-                            ''  => undef,
-                            'r' => ['r'],
-                        }
-                    ],
-                },
-            ],
-        },
-    ],
-    [
-        [ split //, 'o'    ],
-        [ split //, 'on'   ],
-        [ split //, 'one'  ],
-        [ split //, 'only' ],
-        [ split //, 'oner' ],
-    ],
+	[
+		'o',
+		{
+			''  => undef,
+			'n' => [
+				'n', {
+					''  => undef,
+					'l' => ['l', 'y'],
+					'e' => [
+						'e', {
+							''  => undef,
+							'r' => ['r'],
+						}
+					],
+				},
+			],
+		},
+	],
+	[
+		[ split //, 'o'    ],
+		[ split //, 'on'   ],
+		[ split //, 'one'  ],
+		[ split //, 'only' ],
+		[ split //, 'oner' ],
+	],
 );
 
 permute(
-    [
-        'a', 'm',
-        {
-            'a' => [ 'a',
-                {
-                    's' => ['s', 's'],
-                    'z' => ['z', 'e'],
-                },
-            ],
-            'u' => [ 'u',
-                {
-                    'c' => ['c', 'k'],
-                    's' => ['s', 'e'],
-                }
-            ],
-            'b' => [ 'b', 'l', 'e' ],
-        },
-    ],
-    [
-        [ split //, 'amass' ],
-        [ split //, 'amaze' ],
-        [ split //, 'amble' ],
-        [ split //, 'amuck' ],
-        [ split //, 'amuse' ],
-    ],
+	[
+		'a', 'm',
+		{
+			'a' => [ 'a',
+				{
+					's' => ['s', 's'],
+					'z' => ['z', 'e'],
+				},
+			],
+			'u' => [ 'u',
+				{
+					'c' => ['c', 'k'],
+					's' => ['s', 'e'],
+				}
+			],
+			'b' => [ 'b', 'l', 'e' ],
+		},
+	],
+	[
+		[ split //, 'amass' ],
+		[ split //, 'amaze' ],
+		[ split //, 'amble' ],
+		[ split //, 'amuck' ],
+		[ split //, 'amuse' ],
+	],
 );
 
 Regexp::Assemble::Default_Lexer( '\([^(]*(?:\([^)]*\))?[^)]*\)|.' );
 
 {
-    my $r = Regexp::Assemble->new;
+	my $r = Regexp::Assemble->new;
 
-    $r->reset->add( 'ab(cd)ef' );
-    is_deeply( $r->_path,
-        [ 'a', 'b', '(cd)', 'e', 'f' ],
-        'ab(cd)ef (with Default parenthetical lexer)'
-    ) or diag("lex = $r->{lex}");
+	$r->reset->add( 'ab(cd)ef' );
+	is_deeply( $r->_path,
+		[ 'a', 'b', '(cd)', 'e', 'f' ],
+		'ab(cd)ef (with Default parenthetical lexer)'
+	) or diag("lex = $r->{lex}");
 
-    $r->reset->add( 'ab((ef)gh)ij' );
-    is_deeply( $r->_path,
-        [ 'a', 'b', '((ef)gh)', 'i', 'j' ],
-        'ab((ef)gh)ij (with Default parenthetical lexer)'
-    );
+	$r->reset->add( 'ab((ef)gh)ij' );
+	is_deeply( $r->_path,
+		[ 'a', 'b', '((ef)gh)', 'i', 'j' ],
+		'ab((ef)gh)ij (with Default parenthetical lexer)'
+	);
 
-    $r->reset->add( 'ab(ef(gh))ij' );
-    is_deeply( $r->_path,
-        [ 'a', 'b', '(ef(gh))', 'i', 'j' ],
-        'ab(ef(gh))ij (with Default parenthetical lexer)'
-    );
+	$r->reset->add( 'ab(ef(gh))ij' );
+	is_deeply( $r->_path,
+		[ 'a', 'b', '(ef(gh))', 'i', 'j' ],
+		'ab(ef(gh))ij (with Default parenthetical lexer)'
+	);
 
-    eval { $r->filter('choke') };
-    ok( $@, 'die on non-CODE filter' );
+	eval { $r->filter('choke') };
+	ok( $@, 'die on non-CODE filter' );
 
-    eval { $r->pre_filter('choke') };
-    ok( $@, 'die on non-CODE pre_filter' );
+	eval { $r->pre_filter('choke') };
+	ok( $@, 'die on non-CODE pre_filter' );
 }
 
 is( $_, $fixed, '$_ has not been altered' );

--- a/t/02_reduce.t
+++ b/t/02_reduce.t
@@ -11,9 +11,9 @@ use Regexp::Assemble;
 
 eval qq{ use Test::More tests => 61 };
 if( $@ ) {
-    warn "# Test::More not available, no tests performed\n";
-    print "1..1\nok 1\n";
-    exit 0;
+	warn "# Test::More not available, no tests performed\n";
+	print "1..1\nok 1\n";
+	exit 0;
 }
 
 my $fixed = 'The scalar remains the same';
@@ -22,1453 +22,1453 @@ $_ = $fixed;
 my $context = { debug => 0, depth => 0 };
 
 {
-    # ran, reran
-    my $path  = ['r'];
-    my $tail  = { '' => undef, 'r' => [ 'r', 'e' ] };
-    my $head  = ['n', 'a'];
-    ($head, my $slide, $path) = Regexp::Assemble::_slide_tail( $head, $tail, $path, $context );
-    is_deeply( $head, ['n', 'a', 'r'], '_slide_tail ran/reran head' );
-    is_deeply( $slide, { '' => undef, 'e' => ['e', 'r'] }, '_slide_tail ran/reran slide' );
-    is_deeply( $path, [], '_slide_tail ran/reran path' );
+	# ran, reran
+	my $path  = ['r'];
+	my $tail  = { '' => undef, 'r' => [ 'r', 'e' ] };
+	my $head  = ['n', 'a'];
+	($head, my $slide, $path) = Regexp::Assemble::_slide_tail( $head, $tail, $path, $context );
+	is_deeply( $head, ['n', 'a', 'r'], '_slide_tail ran/reran head' );
+	is_deeply( $slide, { '' => undef, 'e' => ['e', 'r'] }, '_slide_tail ran/reran slide' );
+	is_deeply( $path, [], '_slide_tail ran/reran path' );
 }
 
 {
-    # lit, limit
-    my $path  = ['i', 'l'];
-    my $tail  = { '' => undef, 'i' => [ 'i', 'm' ] };
-    my $head  = ['t'];
-    ($head, my $slide, $path) = Regexp::Assemble::_slide_tail( $head, $tail, $path, $context );
-    is_deeply( $head, ['t', 'i'], '_slide_tail lit/limit head' );
-    is_deeply( $slide, { '' => undef, 'm' => ['m', 'i'] }, '_slide_tail lit/limit slide' );
-    is_deeply( $path, ['l'], '_slide_tail lit/limit path' );
+	# lit, limit
+	my $path  = ['i', 'l'];
+	my $tail  = { '' => undef, 'i' => [ 'i', 'm' ] };
+	my $head  = ['t'];
+	($head, my $slide, $path) = Regexp::Assemble::_slide_tail( $head, $tail, $path, $context );
+	is_deeply( $head, ['t', 'i'], '_slide_tail lit/limit head' );
+	is_deeply( $slide, { '' => undef, 'm' => ['m', 'i'] }, '_slide_tail lit/limit slide' );
+	is_deeply( $path, ['l'], '_slide_tail lit/limit path' );
 }
 
 {
-    # acids/acidoids
-    my $path  = ['d', 'i', 'c', 'a'];
-    my $tail  = { '' => undef, 'd' => [ 'd', 'i', 'o' ] };
-    my $head  = ['s'];
-    ($head, my $slide, $path) = Regexp::Assemble::_slide_tail( $head, $tail, $path, $context );
-    is_deeply( $head, ['s', 'd', 'i'], '_slide_tail acids/acidoids head' );
-    is_deeply( $slide, { '' => undef, 'o' => ['o', 'd', 'i'] }, '_slide_tail acids/acidoids slide' );
-    is_deeply( $path, ['c', 'a'], '_slide_tail acids/acidoids path' );
+	# acids/acidoids
+	my $path  = ['d', 'i', 'c', 'a'];
+	my $tail  = { '' => undef, 'd' => [ 'd', 'i', 'o' ] };
+	my $head  = ['s'];
+	($head, my $slide, $path) = Regexp::Assemble::_slide_tail( $head, $tail, $path, $context );
+	is_deeply( $head, ['s', 'd', 'i'], '_slide_tail acids/acidoids head' );
+	is_deeply( $slide, { '' => undef, 'o' => ['o', 'd', 'i'] }, '_slide_tail acids/acidoids slide' );
+	is_deeply( $path, ['c', 'a'], '_slide_tail acids/acidoids path' );
 }
 
 {
-    # 007/00607
-    my $path  = ['0', '0'];
-    my $tail  = { '' => undef, '0' => [ '0', '6' ] };
-    my $head  = ['7'];
-    ($head, my $slide, $path) = Regexp::Assemble::_slide_tail( $head, $tail, $path, $context );
-    is_deeply( $head, ['7', '0'], '_slide_tail 007/00607 head' );
-    is_deeply( $slide, { '' => undef, '6' => ['6', '0'] }, '_slide_tail 007/00607 slide' );
-    is_deeply( $path, ['0'], '_slide_tail 007/00607 path' );
+	# 007/00607
+	my $path  = ['0', '0'];
+	my $tail  = { '' => undef, '0' => [ '0', '6' ] };
+	my $head  = ['7'];
+	($head, my $slide, $path) = Regexp::Assemble::_slide_tail( $head, $tail, $path, $context );
+	is_deeply( $head, ['7', '0'], '_slide_tail 007/00607 head' );
+	is_deeply( $slide, { '' => undef, '6' => ['6', '0'] }, '_slide_tail 007/00607 slide' );
+	is_deeply( $path, ['0'], '_slide_tail 007/00607 path' );
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert($_) for 0..2;
-    $ra->_reduce;
-    is_deeply( $ra->_path,
-        [
-            {
-                '0' => ['0'],
-                '1' => ['1'],
-                '2' => ['2'],
-            },
-        ],
-        '/0/ /1/ /2/',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert($_) for 0..2;
+	$ra->_reduce;
+	is_deeply( $ra->_path,
+		[
+			{
+				'0' => ['0'],
+				'1' => ['1'],
+				'2' => ['2'],
+			},
+		],
+		'/0/ /1/ /2/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'cat' )
-        ->insert( split //, 'dog' )
-        ->insert( split //, 'bird' )
-        ->insert( split //, 'worm' )
-        ->_reduce;
-    is_deeply( $ra->_path,
-        [
-            {
-                'b' => ['b','i','r','d'],
-                'c' => ['c','a','t'],
-                'd' => ['d','o','g'],
-                'w' => ['w','o','r','m'],
-            },
-        ],
-        '/cat/ /dog/ /bird/ /worm/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'cat' )
+		->insert( split //, 'dog' )
+		->insert( split //, 'bird' )
+		->insert( split //, 'worm' )
+		->_reduce;
+	is_deeply( $ra->_path,
+		[
+			{
+				'b' => ['b','i','r','d'],
+				'c' => ['c','a','t'],
+				'd' => ['d','o','g'],
+				'w' => ['w','o','r','m'],
+			},
+		],
+		'/cat/ /dog/ /bird/ /worm/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'proamendment' )
-        ->insert( split //, 'proappropriation' )
-        ->insert( split //, 'proapproval' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            'p', 'r', 'o', 'a',
-            {
-                'm' => ['m','e','n','d','m','e','n','t'],
-                'p' => ['p','p','r','o', {
-                        'p' => ['p','r','i','a','t','i','o','n'],
-                        'v' => ['v','a','l'],
-                    },
-                ],
-            },
-        ],
-        '/proamendment/ /proappropriation/ /proapproval/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'proamendment' )
+		->insert( split //, 'proappropriation' )
+		->insert( split //, 'proapproval' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			'p', 'r', 'o', 'a',
+			{
+				'm' => ['m','e','n','d','m','e','n','t'],
+				'p' => ['p','p','r','o', {
+						'p' => ['p','r','i','a','t','i','o','n'],
+						'v' => ['v','a','l'],
+					},
+				],
+			},
+		],
+		'/proamendment/ /proappropriation/ /proapproval/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->insert( 0 )
-        ->insert( 1 )
-        ->insert( split //, 10 )
-        ->insert( split //, 100 )
-        ->_reduce;
-    is_deeply( $ra->_path,
-        [
-            {
-                '0' => ['0'],
-                '1' => [
-                    '1', {
-                        ''  => undef,
-                        '0' => [
-                            {
-                                '' => undef,
-                                '0' => ['0'],
-                            },
-                            0,
-                        ],
-                    }
-                ],
-            },
-        ],
-        '/0/ /1/ /10/ /100/',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->insert( 0 )
+		->insert( 1 )
+		->insert( split //, 10 )
+		->insert( split //, 100 )
+		->_reduce;
+	is_deeply( $ra->_path,
+		[
+			{
+				'0' => ['0'],
+				'1' => [
+					'1', {
+						''  => undef,
+						'0' => [
+							{
+								'' => undef,
+								'0' => ['0'],
+							},
+							0,
+						],
+					}
+				],
+			},
+		],
+		'/0/ /1/ /10/ /100/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( 'c', 'a', 'b' )
-        ->insert( 'd', 'a', 'b' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'c' => ['c'],
-                'd' => ['d'],
-            },
-            'a', 'b',
-        ],
-        '/cab/ /dab/'
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( 'c', 'a', 'b' )
+		->insert( 'd', 'a', 'b' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'c' => ['c'],
+				'd' => ['d'],
+			},
+			'a', 'b',
+		],
+		'/cab/ /dab/'
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( 'c', 'r', 'a', 'b' )
-        ->insert( 'd', 'a', 'b' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'c' => ['c', 'r'],
-                'd' => ['d'],
-            },
-            'a', 'b',
-        ],
-        '/crab/ /dab/'
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( 'c', 'r', 'a', 'b' )
+		->insert( 'd', 'a', 'b' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'c' => ['c', 'r'],
+				'd' => ['d'],
+			},
+			'a', 'b',
+		],
+		'/crab/ /dab/'
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( 'd', 'a', 'b' )
-        ->insert( 'd', 'a', 'y' )
-        ->insert( 'd', 'a', 'i', 'l', 'y' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            'd', 'a',
-            {
-                'b' => ['b'],
-                'i' => [
-                    {
-                        ''  => undef,
-                        'i' => ['i', 'l'],
-                    },
-                    'y'
-                ],
-            },
-        ],
-        '/dab/ /day /daily/'
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( 'd', 'a', 'b' )
+		->insert( 'd', 'a', 'y' )
+		->insert( 'd', 'a', 'i', 'l', 'y' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			'd', 'a',
+			{
+				'b' => ['b'],
+				'i' => [
+					{
+						''  => undef,
+						'i' => ['i', 'l'],
+					},
+					'y'
+				],
+			},
+		],
+		'/dab/ /day /daily/'
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( 'c', 'r', 'a', 'b' )
-        ->insert( 'd', 'a', 'b' )
-        ->insert( 'l', 'o', 'b' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'c' => [
-                    {
-                        'c' => ['c', 'r'],
-                        'd' => ['d'],
-                    },
-                    'a',
-                ],
-                'l' => ['l', 'o'],
-            },
-            'b',
-        ],
-        '/crab/ /dab/ /lob/'
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( 'c', 'r', 'a', 'b' )
+		->insert( 'd', 'a', 'b' )
+		->insert( 'l', 'o', 'b' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'c' => [
+					{
+						'c' => ['c', 'r'],
+						'd' => ['d'],
+					},
+					'a',
+				],
+				'l' => ['l', 'o'],
+			},
+			'b',
+		],
+		'/crab/ /dab/ /lob/'
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'hat' )
-        ->insert( split //, 'that' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                '' => undef,
-                't' => ['t'],
-            },
-            'h', 'a', 't',
-        ],
-        '/hat/ /that/'
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'hat' )
+		->insert( split //, 'that' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'' => undef,
+				't' => ['t'],
+			},
+			'h', 'a', 't',
+		],
+		'/hat/ /that/'
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'treat' )
-        ->insert( split //, 'threat' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            't',
-            {
-                '' => undef,
-                'h' => ['h'],
-            },
-            'r', 'e', 'a', 't'
-        ],
-        '/treat/ /threat/'
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'treat' )
+		->insert( split //, 'threat' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			't',
+			{
+				'' => undef,
+				'h' => ['h'],
+			},
+			'r', 'e', 'a', 't'
+		],
+		'/treat/ /threat/'
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'treat' )
-        ->insert( split //, 'threat' )
-        ->insert( split //, 'eat' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                '' => undef,
-                't' => [
-                    't',
-                    {
-                        '' => undef,
-                        'h' => ['h'],
-                    },
-                    'r',
-                ],
-            },
-            'e', 'a', 't'
-        ],
-        '/eat/ /treat/ /threat/'
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'treat' )
+		->insert( split //, 'threat' )
+		->insert( split //, 'eat' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'' => undef,
+				't' => [
+					't',
+					{
+						'' => undef,
+						'h' => ['h'],
+					},
+					'r',
+				],
+			},
+			'e', 'a', 't'
+		],
+		'/eat/ /treat/ /threat/'
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'treat' )
-        ->insert( split //, 'threat' )
-        ->insert( split //, 'teat' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            't',
-            {
-                ''  => undef,
-                'h' => [
-                    {
-                        'h' => ['h'],
-                        ''  => undef,
-                    },
-                    'r'
-                ],
-            },
-            'e', 'a', 't'
-        ],
-        '/teat/ /treat/ /threat/'
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'treat' )
+		->insert( split //, 'threat' )
+		->insert( split //, 'teat' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			't',
+			{
+				''  => undef,
+				'h' => [
+					{
+						'h' => ['h'],
+						''  => undef,
+					},
+					'r'
+				],
+			},
+			'e', 'a', 't'
+		],
+		'/teat/ /treat/ /threat/'
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'grit' )
-        ->insert( split //, 'lit' )
-        ->insert( split //, 'limit' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'g' => [ 'g', 'r' ],
-                'l' => [ 'l',
-                    {
-                        ''  => undef,
-                        'i' => ['i', 'm'],
-                    },
-                ],
-            },
-            'i', 't'
-        ],
-        '/grit/ /lit/ /limit/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'grit' )
+		->insert( split //, 'lit' )
+		->insert( split //, 'limit' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'g' => [ 'g', 'r' ],
+				'l' => [ 'l',
+					{
+						''  => undef,
+						'i' => ['i', 'm'],
+					},
+				],
+			},
+			'i', 't'
+		],
+		'/grit/ /lit/ /limit/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'in' )
-        ->insert( split //, 'ban' )
-        ->insert( split //, 'ten' )
-        ->insert( split //, 'tent' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'b' => [
-                    {
-                        'i' => ['i'],
-                        'b' => ['b', 'a'],
-                    },
-                    'n',
-                ],
-                't' => ['t', 'e', 'n',
-                    {
-                        ''  => undef,
-                        't' => ['t'],
-                    }
-                ]
-            }
-        ],
-        '/in/ /ban/ /ten/ /tent/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'in' )
+		->insert( split //, 'ban' )
+		->insert( split //, 'ten' )
+		->insert( split //, 'tent' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'b' => [
+					{
+						'i' => ['i'],
+						'b' => ['b', 'a'],
+					},
+					'n',
+				],
+				't' => ['t', 'e', 'n',
+					{
+						''  => undef,
+						't' => ['t'],
+					}
+				]
+			}
+		],
+		'/in/ /ban/ /ten/ /tent/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( '' )
-        ->insert( split //, 'do' )
-        ->insert( split //, 'don' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                ''  => undef,
-                'd' => [  'd', 'o',
-                    {
-                        ''  => undef,
-                        'n' => ['n'],
-                    },
-                ],
-            }
-        ],
-        '// /do/ /don/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( '' )
+		->insert( split //, 'do' )
+		->insert( split //, 'don' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				''  => undef,
+				'd' => [  'd', 'o',
+					{
+						''  => undef,
+						'n' => ['n'],
+					},
+				],
+			}
+		],
+		'// /do/ /don/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'bf' )
-        ->insert( split //, 'cdf' )
-        ->insert( split //, 'cgf' )
-        ->insert( split //, 'cez' )
-        ->insert( split //, 'daf' )
-        ->insert( split //, 'dbf' )
-        ->insert( split //, 'dcf' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'b' => [
-                    {
-                        'b' => ['b'],
-                        'd' => ['d',
-                            {
-                                'a'=>['a'],
-                                'b'=>['b'],
-                                'c'=>['c'],
-                            },
-                        ],
-                    },
-                    'f',
-                ],
-                'c' => [ 'c', {
-                        'd' => [
-                            {
-                                'd' => ['d'],
-                                'g' => ['g'],
-                            },
-                            'f',
-                        ],
-                        'e' => ['e', 'z'],
-                    }
-                ],
-            }
-        ],
-        '/bf/ /cdf/ /cgf/ /cez/ /daf/ /dbf/ /dcf/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'bf' )
+		->insert( split //, 'cdf' )
+		->insert( split //, 'cgf' )
+		->insert( split //, 'cez' )
+		->insert( split //, 'daf' )
+		->insert( split //, 'dbf' )
+		->insert( split //, 'dcf' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'b' => [
+					{
+						'b' => ['b'],
+						'd' => ['d',
+							{
+								'a'=>['a'],
+								'b'=>['b'],
+								'c'=>['c'],
+							},
+						],
+					},
+					'f',
+				],
+				'c' => [ 'c', {
+						'd' => [
+							{
+								'd' => ['d'],
+								'g' => ['g'],
+							},
+							'f',
+						],
+						'e' => ['e', 'z'],
+					}
+				],
+			}
+		],
+		'/bf/ /cdf/ /cgf/ /cez/ /daf/ /dbf/ /dcf/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'kids' )
-        ->insert( split //, 'acids' )
-        ->insert( split //, 'acidoids' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'k' => [ 'k' ],
-                'a' => [ 'a', 'c',
-                    {
-                        '' => undef,
-                        'i' => ['i', 'd', 'o'],
-                    },
-                ],
-            },
-            'i', 'd', 's',
-        ],
-        '/kids/ /acids/ /acidoids/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'kids' )
+		->insert( split //, 'acids' )
+		->insert( split //, 'acidoids' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'k' => [ 'k' ],
+				'a' => [ 'a', 'c',
+					{
+						'' => undef,
+						'i' => ['i', 'd', 'o'],
+					},
+				],
+			},
+			'i', 'd', 's',
+		],
+		'/kids/ /acids/ /acidoids/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'schoolkids' )
-        ->insert( split //, 'acids' )
-        ->insert( split //, 'acidoids' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                's' => [ 's', 'c', 'h', 'o', 'o', 'l', 'k' ],
-                'a' => [ 'a', 'c',
-                    {
-                        '' => undef,
-                        'i' => ['i', 'd', 'o'],
-                    },
-                ],
-            },
-            'i', 'd', 's',
-        ],
-        '/schoolkids/ /acids/ /acidoids/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'schoolkids' )
+		->insert( split //, 'acids' )
+		->insert( split //, 'acidoids' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				's' => [ 's', 'c', 'h', 'o', 'o', 'l', 'k' ],
+				'a' => [ 'a', 'c',
+					{
+						'' => undef,
+						'i' => ['i', 'd', 'o'],
+					},
+				],
+			},
+			'i', 'd', 's',
+		],
+		'/schoolkids/ /acids/ /acidoids/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'skids' )
-        ->insert( split //, 'kids' )
-        ->insert( split //, 'acids' )
-        ->insert( split //, 'acidoids' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                's' => [
-                    {
-                        ''  => undef,
-                        's' => ['s'],
-                    },
-                    'k',
-                ],
-                'a' => [ 'a', 'c',
-                    {
-                        '' => undef,
-                        'i' => ['i', 'd', 'o'],
-                    },
-                ],
-            },
-            'i', 'd', 's',
-        ],
-        '/skids/ /kids/ /acids/ /acidoids/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'skids' )
+		->insert( split //, 'kids' )
+		->insert( split //, 'acids' )
+		->insert( split //, 'acidoids' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				's' => [
+					{
+						''  => undef,
+						's' => ['s'],
+					},
+					'k',
+				],
+				'a' => [ 'a', 'c',
+					{
+						'' => undef,
+						'i' => ['i', 'd', 'o'],
+					},
+				],
+			},
+			'i', 'd', 's',
+		],
+		'/skids/ /kids/ /acids/ /acidoids/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'skids' )
-        ->insert( split //, 'kids' )
-        ->insert( split //, 'acids' )
-        ->insert( split //, 'acidoids' )
-        ->insert( split //, 'schoolkids' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                's' => [
-                    {
-                        ''  => undef,
-                        's' => ['s',
-                            {
-                                ''  => undef,
-                                'c' => ['c', 'h', 'o', 'o', 'l'],
-                            }
-                        ],
-                    },
-                    'k',
-                ],
-                'a' => [ 'a', 'c',
-                    {
-                        '' => undef,
-                        'i' => ['i', 'd', 'o'],
-                    },
-                ],
-            },
-            'i', 'd', 's',
-        ],
-        '/skids/ /kids/ /acids/ /acidoids/ /schoolkids/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'skids' )
+		->insert( split //, 'kids' )
+		->insert( split //, 'acids' )
+		->insert( split //, 'acidoids' )
+		->insert( split //, 'schoolkids' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				's' => [
+					{
+						''  => undef,
+						's' => ['s',
+							{
+								''  => undef,
+								'c' => ['c', 'h', 'o', 'o', 'l'],
+							}
+						],
+					},
+					'k',
+				],
+				'a' => [ 'a', 'c',
+					{
+						'' => undef,
+						'i' => ['i', 'd', 'o'],
+					},
+				],
+			},
+			'i', 'd', 's',
+		],
+		'/skids/ /kids/ /acids/ /acidoids/ /schoolkids/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'showeriness' )
-        ->insert( split //, 'showerless' )
-        ->insert( split //, 'showiness' )
-        ->insert( split //, 'showless' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            's', 'h', 'o', 'w',
-            {
-                ''  => undef,
-                'e' => ['e', 'r'],
-            },
-            {
-                'i' => ['i', 'n'],
-                'l' => ['l'],
-            },
-            'e', 's', 's'
-        ],
-        '/showeriness/ /showerless/ /showiness/ /showless/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'showeriness' )
+		->insert( split //, 'showerless' )
+		->insert( split //, 'showiness' )
+		->insert( split //, 'showless' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			's', 'h', 'o', 'w',
+			{
+				''  => undef,
+				'e' => ['e', 'r'],
+			},
+			{
+				'i' => ['i', 'n'],
+				'l' => ['l'],
+			},
+			'e', 's', 's'
+		],
+		'/showeriness/ /showerless/ /showiness/ /showless/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'gait' )
-        ->insert( split //, 'grit' )
-        ->insert( split //, 'blaze' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'b' => ['b', 'l', 'a', 'z', 'e'],
-                'g' => ['g',
-                    {
-                        'a' => ['a'],
-                        'r' => ['r'],
-                    },
-                    'i', 't',
-                ],
-            },
-        ],
-        '/gait/ /grit/ /blaze/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'gait' )
+		->insert( split //, 'grit' )
+		->insert( split //, 'blaze' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'b' => ['b', 'l', 'a', 'z', 'e'],
+				'g' => ['g',
+					{
+						'a' => ['a'],
+						'r' => ['r'],
+					},
+					'i', 't',
+				],
+			},
+		],
+		'/gait/ /grit/ /blaze/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'gait' )
-        ->insert( split //, 'grit' )
-        ->insert( split //, 'glaze' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            'g',
-            {
-                'l' => ['l', 'a', 'z', 'e'],
-                'a' => [
-                    {
-                        'a' => ['a'],
-                        'r' => ['r'],
-                    },
-                    'i', 't',
-                ],
-            },
-        ],
-        '/gait/ /grit/ /glaze/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'gait' )
+		->insert( split //, 'grit' )
+		->insert( split //, 'glaze' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			'g',
+			{
+				'l' => ['l', 'a', 'z', 'e'],
+				'a' => [
+					{
+						'a' => ['a'],
+						'r' => ['r'],
+					},
+					'i', 't',
+				],
+			},
+		],
+		'/gait/ /grit/ /glaze/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'gait' )
-        ->insert( split //, 'grit' )
-        ->insert( split //, 'graze' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            'g',
-            {
-                'r' => ['r',
-                    {
-                        'a' => ['a', 'z', 'e'],
-                        'i' => ['i', 't'],
-                    },
-                ],
-                'a' => ['a', 'i', 't'],
-            },
-        ],
-        '/gait/ /grit/ /graze/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'gait' )
+		->insert( split //, 'grit' )
+		->insert( split //, 'graze' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			'g',
+			{
+				'r' => ['r',
+					{
+						'a' => ['a', 'z', 'e'],
+						'i' => ['i', 't'],
+					},
+				],
+				'a' => ['a', 'i', 't'],
+			},
+		],
+		'/gait/ /grit/ /graze/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->{path} = [
-        't', {
-            'a' => ['a'],
-            'i' => ['i'],
-        },
-        'b',
-    ];
-    my $path = [ 't', {
-            'a' => ['a'],
-            'i' => ['i'],
-        },
-        's',
-    ];
-    my $res = $ra->_insert_path( $ra->{path}, 0, $path );
-    is_deeply( $res,
-        [
-            't',
-            {
-                'a' => ['a'],
-                'i' => ['i'],
-            },
-            {
-                'b' => ['b'],
-                's' => ['s'],
-            },
-        ],
-        '_insert_path sit/sat -> bit/bat',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->{path} = [
+		't', {
+			'a' => ['a'],
+			'i' => ['i'],
+		},
+		'b',
+	];
+	my $path = [ 't', {
+			'a' => ['a'],
+			'i' => ['i'],
+		},
+		's',
+	];
+	my $res = $ra->_insert_path( $ra->{path}, 0, $path );
+	is_deeply( $res,
+		[
+			't',
+			{
+				'a' => ['a'],
+				'i' => ['i'],
+			},
+			{
+				'b' => ['b'],
+				's' => ['s'],
+			},
+		],
+		'_insert_path sit/sat -> bit/bat',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->{path} = [
-        't', {
-            'a' => ['a'],
-            'i' => ['i'],
-        },
-        {
-            'b' => ['b'],
-            's' => ['s'],
-        }
-    ];
-    my $path = [ 't', {
-            'a' => ['a'],
-            'i' => ['i'],
-        },
-        'f',
-    ];
-    my $res = $ra->_insert_path( $ra->{path}, 0, $path );
-    is_deeply( $res,
-        [
-            't',
-            {
-                'a' => ['a'],
-                'i' => ['i'],
-            },
-            {
-                'b' => ['b'],
-                'f' => ['f'],
-                's' => ['s'],
-            },
-        ],
-        '_insert_path fit/fat -> sit/sat, bit/bat',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->{path} = [
+		't', {
+			'a' => ['a'],
+			'i' => ['i'],
+		},
+		{
+			'b' => ['b'],
+			's' => ['s'],
+		}
+	];
+	my $path = [ 't', {
+			'a' => ['a'],
+			'i' => ['i'],
+		},
+		'f',
+	];
+	my $res = $ra->_insert_path( $ra->{path}, 0, $path );
+	is_deeply( $res,
+		[
+			't',
+			{
+				'a' => ['a'],
+				'i' => ['i'],
+			},
+			{
+				'b' => ['b'],
+				'f' => ['f'],
+				's' => ['s'],
+			},
+		],
+		'_insert_path fit/fat -> sit/sat, bit/bat',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->{path} = [
-        't', {
-            ''  => undef,
-            'a' => ['a'],
-        },
-        'e', 'b',
-    ];
-    my $path = [ 't', {
-            ''  => undef,
-            'a' => ['a'],
-        },
-        'e', 's',
-    ];
-    my $res = $ra->_insert_path( $ra->{path}, 0, $path );
-    is_deeply( $res,
-        [
-            't',
-            {
-                ''  => undef,
-                'a' => ['a'],
-            },
-            'e',
-            {
-                'b' => ['b'],
-                's' => ['s'],
-            },
-        ],
-        '_insert_path seat/set -> beat/bet',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->{path} = [
+		't', {
+			''  => undef,
+			'a' => ['a'],
+		},
+		'e', 'b',
+	];
+	my $path = [ 't', {
+			''  => undef,
+			'a' => ['a'],
+		},
+		'e', 's',
+	];
+	my $res = $ra->_insert_path( $ra->{path}, 0, $path );
+	is_deeply( $res,
+		[
+			't',
+			{
+				''  => undef,
+				'a' => ['a'],
+			},
+			'e',
+			{
+				'b' => ['b'],
+				's' => ['s'],
+			},
+		],
+		'_insert_path seat/set -> beat/bet',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->{path} = [
-        'd', 'i',
-        {
-            ''  => undef,
-            'o' => ['o'],
-        },
-        't', 'y', 'd',
-    ];
-    my $path = [ 'd', 'i',
-        {
-            ''  => undef,
-            'o' => ['o'],
-        },
-        't', 'a', 'b',
-    ];
-    my $res = $ra->_insert_path( $ra->{path}, 0, $path );
-    is_deeply( $res,
-        [
-            'd', 'i',
-            {
-                ''  => undef,
-                'o' => ['o'],
-            },
-            't',
-            {
-                'a' => ['a', 'b'],
-                'y' => ['y', 'd'],
-            },
-        ],
-        '_insert_path dio?tyd -> dio?tab',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->{path} = [
+		'd', 'i',
+		{
+			''  => undef,
+			'o' => ['o'],
+		},
+		't', 'y', 'd',
+	];
+	my $path = [ 'd', 'i',
+		{
+			''  => undef,
+			'o' => ['o'],
+		},
+		't', 'a', 'b',
+	];
+	my $res = $ra->_insert_path( $ra->{path}, 0, $path );
+	is_deeply( $res,
+		[
+			'd', 'i',
+			{
+				''  => undef,
+				'o' => ['o'],
+			},
+			't',
+			{
+				'a' => ['a', 'b'],
+				'y' => ['y', 'd'],
+			},
+		],
+		'_insert_path dio?tyd -> dio?tab',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->{path} = [
-        'd', 'i',
-        {
-            ''  => undef,
-            'o' => ['o'],
-        },
-        't',
-        {
-            'a' => ['a', 'b'],
-            'y' => ['y', 'd'],
-        },
-    ];
-    my $path = [ 'd', 'i',
-        {
-            ''  => undef,
-            'o' => ['o'],
-        },
-        't', 'm', 'x',
-    ];
-    my $res = $ra->_insert_path( $ra->{path}, 0, $path );
-    is_deeply( $res,
-        [
-            'd', 'i',
-            {
-                ''  => undef,
-                'o' => ['o'],
-            },
-            't',
-            {
-                'a' => ['a', 'b'],
-                'm' => ['m', 'x'],
-                'y' => ['y', 'd'],
-            },
-        ],
-        '_insert_path dio?tmx -> dio?t(ab|yd)',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->{path} = [
+		'd', 'i',
+		{
+			''  => undef,
+			'o' => ['o'],
+		},
+		't',
+		{
+			'a' => ['a', 'b'],
+			'y' => ['y', 'd'],
+		},
+	];
+	my $path = [ 'd', 'i',
+		{
+			''  => undef,
+			'o' => ['o'],
+		},
+		't', 'm', 'x',
+	];
+	my $res = $ra->_insert_path( $ra->{path}, 0, $path );
+	is_deeply( $res,
+		[
+			'd', 'i',
+			{
+				''  => undef,
+				'o' => ['o'],
+			},
+			't',
+			{
+				'a' => ['a', 'b'],
+				'm' => ['m', 'x'],
+				'y' => ['y', 'd'],
+			},
+		],
+		'_insert_path dio?tmx -> dio?t(ab|yd)',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->{path} = [
-        'd', 'i',
-        {
-            ''  => undef,
-            'o' => ['o'],
-        },
-        't',
-        {
-            'a' => ['a', 'b'],
-            'y' => ['y', 'd'],
-        },
-    ];
-    my $path = [ 'd', 'i',
-        {
-            ''  => undef,
-            'o' => ['o'],
-        },
-        't', 'a', 'x',
-    ];
-    my $res = $ra->_insert_path( $ra->{path}, 0, $path );
-    is_deeply( $res,
-        [
-            'd', 'i',
-            {
-                ''  => undef,
-                'o' => ['o'],
-            },
-            't',
-            {
-                'a' => ['a',
-                    {
-                        'b' => ['b'],
-                        'x' => ['x'],
-                    }
-                ],
-                'y' => ['y', 'd'],
-            },
-        ],
-        '_insert_path dio?tax -> dio?t(ab|yd)',
-    );
+	my $ra = Regexp::Assemble->new;
+	$ra->{path} = [
+		'd', 'i',
+		{
+			''  => undef,
+			'o' => ['o'],
+		},
+		't',
+		{
+			'a' => ['a', 'b'],
+			'y' => ['y', 'd'],
+		},
+	];
+	my $path = [ 'd', 'i',
+		{
+			''  => undef,
+			'o' => ['o'],
+		},
+		't', 'a', 'x',
+	];
+	my $res = $ra->_insert_path( $ra->{path}, 0, $path );
+	is_deeply( $res,
+		[
+			'd', 'i',
+			{
+				''  => undef,
+				'o' => ['o'],
+			},
+			't',
+			{
+				'a' => ['a',
+					{
+						'b' => ['b'],
+						'x' => ['x'],
+					}
+				],
+				'y' => ['y', 'd'],
+			},
+		],
+		'_insert_path dio?tax -> dio?t(ab|yd)',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'gait' )
-        ->insert( split //, 'grit' )
-        ->insert( split //, 'summit' )
-        ->insert( split //, 'submit' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'g' => ['g',
-                    {
-                        'a' => ['a'],
-                        'r' => ['r'],
-                    },
-                ],
-                's' => [
-                    's', 'u',
-                    {
-                        'b' => ['b'],
-                        'm' => ['m'],
-                    },
-                    'm',
-                ],
-            },
-            'i', 't',
-        ],
-        '/gait/ /grit/ /summit/ /submit/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'gait' )
+		->insert( split //, 'grit' )
+		->insert( split //, 'summit' )
+		->insert( split //, 'submit' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'g' => ['g',
+					{
+						'a' => ['a'],
+						'r' => ['r'],
+					},
+				],
+				's' => [
+					's', 'u',
+					{
+						'b' => ['b'],
+						'm' => ['m'],
+					},
+					'm',
+				],
+			},
+			'i', 't',
+		],
+		'/gait/ /grit/ /summit/ /submit/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'gait' )
-        ->insert( split //, 'grit' )
-        ->insert( split //, 'summit' )
-        ->insert( split //, 'submit' )
-        ->insert( split //, 'it' )
-        ->insert( split //, 'emit' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                ''  => undef,
-                'g' => ['g',
-                    {
-                        'a' => ['a'],
-                        'r' => ['r'],
-                    },
-                ],
-                'e' => [
-                    {
-                        'e' => ['e'],
-                        's' => ['s', 'u',
-                            {
-                                'b' => ['b'],
-                                'm' => ['m'],
-                            },
-                        ],
-                    },
-                    'm',
-                ],
-            },
-            'i', 't',
-        ],
-        '/gait/ /grit/ /summit/ /submit/ /it/ /emit/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'gait' )
+		->insert( split //, 'grit' )
+		->insert( split //, 'summit' )
+		->insert( split //, 'submit' )
+		->insert( split //, 'it' )
+		->insert( split //, 'emit' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				''  => undef,
+				'g' => ['g',
+					{
+						'a' => ['a'],
+						'r' => ['r'],
+					},
+				],
+				'e' => [
+					{
+						'e' => ['e'],
+						's' => ['s', 'u',
+							{
+								'b' => ['b'],
+								'm' => ['m'],
+							},
+						],
+					},
+					'm',
+				],
+			},
+			'i', 't',
+		],
+		'/gait/ /grit/ /summit/ /submit/ /it/ /emit/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'gait' )
-        ->insert( split //, 'grit' )
-        ->insert( split //, 'lit' )
-        ->insert( split //, 'limit' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'g' => ['g',
-                    {
-                        'a' => ['a'],
-                        'r' => ['r'],
-                    },
-                ],
-                'l' => [ 'l',
-                    {
-                        ''  => undef,
-                        'i' => ['i','m'],
-                    },
-                ],
-            },
-            'i', 't',
-        ],
-        '/gait/ /grit/ /lit/ /limit/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'gait' )
+		->insert( split //, 'grit' )
+		->insert( split //, 'lit' )
+		->insert( split //, 'limit' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'g' => ['g',
+					{
+						'a' => ['a'],
+						'r' => ['r'],
+					},
+				],
+				'l' => [ 'l',
+					{
+						''  => undef,
+						'i' => ['i','m'],
+					},
+				],
+			},
+			'i', 't',
+		],
+		'/gait/ /grit/ /lit/ /limit/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'gait' )
-        ->insert( split //, 'grit' )
-        ->insert( split //, 'bait' )
-        ->insert( split //, 'brit' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'b' => ['b'],
-                'g' => ['g'],
-            },
-            {
-                'a' => ['a'],
-                'r' => ['r'],
-            },
-            'i', 't',
-        ],
-        '/gait/ /grit/ /bait/ /brit/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'gait' )
+		->insert( split //, 'grit' )
+		->insert( split //, 'bait' )
+		->insert( split //, 'brit' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'b' => ['b'],
+				'g' => ['g'],
+			},
+			{
+				'a' => ['a'],
+				'r' => ['r'],
+			},
+			'i', 't',
+		],
+		'/gait/ /grit/ /bait/ /brit/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'gait' )
-        ->insert( split //, 'grit' )
-        ->insert( split //, 'bebait' )
-        ->insert( split //, 'bait' )
-        ->insert( split //, 'brit' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'b' => ['b',
-                    {
-                        'e' => [
-                            {
-                                ''  => undef,
-                                'e' => ['e','b'],
-                            },
-                            'a',
-                        ],
-                        'r' => ['r'],
-                    },
-                ],
-                'g' => ['g',
-                    {
-                        'a' => ['a'],
-                        'r' => ['r'],
-                    }
-                ]
-            },
-            'i', 't',
-        ],
-        '/gait/ /grit/ /bait/ /bebait/ /brit/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'gait' )
+		->insert( split //, 'grit' )
+		->insert( split //, 'bebait' )
+		->insert( split //, 'bait' )
+		->insert( split //, 'brit' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'b' => ['b',
+					{
+						'e' => [
+							{
+								''  => undef,
+								'e' => ['e','b'],
+							},
+							'a',
+						],
+						'r' => ['r'],
+					},
+				],
+				'g' => ['g',
+					{
+						'a' => ['a'],
+						'r' => ['r'],
+					}
+				]
+			},
+			'i', 't',
+		],
+		'/gait/ /grit/ /bait/ /bebait/ /brit/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'gait' )
-        ->insert( split //, 'grit' )
-        ->insert( split //, 'bait' )
-        ->insert( split //, 'brit' )
-        ->insert( split //, 'summit' )
-        ->insert( split //, 'submit' )
-        ->insert( split //, 'emit' )
-        ->insert( split //, 'transmit' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'b' => [
-                    {
-                        'b' => ['b'],
-                        'g' => ['g'],
-                    },
-                    {
-                        'a' => ['a'],
-                        'r' => ['r'],
-                    },
-                ],
-                'e' => [
-                    {
-                        'e' => ['e'],
-                        's' => ['s','u',{'b'=>['b'],'m'=>['m']}],
-                        't' => ['t','r','a','n','s'],
-                    },
-                    'm',
-                ],
-            },
-            'i', 't',
-        ],
-        '/gait/ /grit/ /bait/ /brit/ /emit/ /summit/ /submit/ /transmit/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'gait' )
+		->insert( split //, 'grit' )
+		->insert( split //, 'bait' )
+		->insert( split //, 'brit' )
+		->insert( split //, 'summit' )
+		->insert( split //, 'submit' )
+		->insert( split //, 'emit' )
+		->insert( split //, 'transmit' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'b' => [
+					{
+						'b' => ['b'],
+						'g' => ['g'],
+					},
+					{
+						'a' => ['a'],
+						'r' => ['r'],
+					},
+				],
+				'e' => [
+					{
+						'e' => ['e'],
+						's' => ['s','u',{'b'=>['b'],'m'=>['m']}],
+						't' => ['t','r','a','n','s'],
+					},
+					'm',
+				],
+			},
+			'i', 't',
+		],
+		'/gait/ /grit/ /bait/ /brit/ /emit/ /summit/ /submit/ /transmit/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'lit' )
-        ->insert( split //, 'limit' )
-        ->insert( split //, 'commit' )
-        ->insert( split //, 'emit' )
-        ->insert( split //, 'transmit' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path,
-        [
-            {
-                'c' => [
-                    {
-                        'c' => ['c','o','m'],
-                        'e' => ['e'],
-                        't' => ['t','r','a','n','s'],
-                    },
-                    'm',
-                ],
-                'l' => ['l',
-                    {
-                        ''  => undef,
-                        'i' => ['i','m'],
-                    },
-                ],
-            },
-            'i', 't',
-        ],
-        '/lit/ /limit/ /emit/ /commit/ /transmit/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'lit' )
+		->insert( split //, 'limit' )
+		->insert( split //, 'commit' )
+		->insert( split //, 'emit' )
+		->insert( split //, 'transmit' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			{
+				'c' => [
+					{
+						'c' => ['c','o','m'],
+						'e' => ['e'],
+						't' => ['t','r','a','n','s'],
+					},
+					'm',
+				],
+				'l' => ['l',
+					{
+						''  => undef,
+						'i' => ['i','m'],
+					},
+				],
+			},
+			'i', 't',
+		],
+		'/lit/ /limit/ /emit/ /commit/ /transmit/',
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new
-        ->insert( split //, 'apocryphal' )
-        ->insert( split //, 'apocrustic' )
-        ->insert( split //, 'apocrenic' )
-        ->_reduce
-    ;
-    is_deeply( $ra->_path, 
-        [
-            'a','p','o','c','r',
-            {
-                'e' => [
-                    {
-                        'e' => ['e', 'n'],
-                        'u' => ['u', 's', 't'],
-                    },
-                    'i','c',
-                ],
-                'y' => ['y','p','h','a','l'],
-            },
-        ],
-        '/apocryphal/ /apocrustic/ /apocrenic/',
-    );
+	my $ra = Regexp::Assemble->new
+		->insert( split //, 'apocryphal' )
+		->insert( split //, 'apocrustic' )
+		->insert( split //, 'apocrenic' )
+		->_reduce
+	;
+	is_deeply( $ra->_path,
+		[
+			'a','p','o','c','r',
+			{
+				'e' => [
+					{
+						'e' => ['e', 'n'],
+						'u' => ['u', 's', 't'],
+					},
+					'i','c',
+				],
+				'y' => ['y','p','h','a','l'],
+			},
+		],
+		'/apocryphal/ /apocrustic/ /apocrenic/',
+	);
 }
 
 {
-    my @list = qw/ den dent din dint ten tent tin tint /;
-    my $ra = Regexp::Assemble->new;
-    # $ra->insert( split // ) for @list;
-    for my $l (@list) { $ra->insert( split //, $l ) }
-    $ra->_reduce;
-    is_deeply( $ra->_path, [
-            {
-                'd' => ['d',
-                    {
-                        'e' => [ 'e', 'n', {
-                                ''  => undef,
-                                't' => ['t'],
-                            },
-                        ],
-                        'i' => [ 'i', 'n', {
-                                ''  => undef,
-                                't' => ['t'],
-                            },
-                        ],
-                    },
-                ],
-                't' => ['t',
-                    {
-                        'e' => [ 'e', 'n', {
-                                ''  => undef,
-                                't' => ['t'],
-                            },
-                        ],
-                        'i' => [ 'i', 'n', {
-                                ''  => undef,
-                                't' => ['t'],
-                            },
-                        ],
-                    },
-                ],
-            },
-        ],
-        join( ' ', map { "/$_/" } @list ),
-    );
+	my @list = qw/ den dent din dint ten tent tin tint /;
+	my $ra = Regexp::Assemble->new;
+	# $ra->insert( split // ) for @list;
+	for my $l (@list) { $ra->insert( split //, $l ) }
+	$ra->_reduce;
+	is_deeply( $ra->_path, [
+			{
+				'd' => ['d',
+					{
+						'e' => [ 'e', 'n', {
+								''  => undef,
+								't' => ['t'],
+							},
+						],
+						'i' => [ 'i', 'n', {
+								''  => undef,
+								't' => ['t'],
+							},
+						],
+					},
+				],
+				't' => ['t',
+					{
+						'e' => [ 'e', 'n', {
+								''  => undef,
+								't' => ['t'],
+							},
+						],
+						'i' => [ 'i', 'n', {
+								''  => undef,
+								't' => ['t'],
+							},
+						],
+					},
+				],
+			},
+		],
+		join( ' ', map { "/$_/" } @list ),
+	);
 }
 
 {
-    my @list = qw/ gait git grapefruit grassquit grit guitguit /;
-    my $ra = Regexp::Assemble->new;
-    # $ra->insert( split // ) for @list;
-    for my $l (@list) { $ra->insert( split //, $l ) }
-    $ra->_reduce;
-    is_deeply( $ra->_path,
-        [ 'g',
-            { 
-                ''  => undef,
-                'a' => ['a'],
-                'r' => ['r',
-                    {
-                        ''  => undef,
-                        'a' => ['a',
-                            {
-                                'p' => ['p','e','f','r'],
-                                's' => ['s','s','q'],
-                            },
-                            'u',
-                        ],
-                    },
-                ],
-                'u' => [ 'u','i','t','g','u'],
-            },
-            'i', 't'
-        ],
-        join( ' ', map { "/$_/" } @list ),
-    );
+	my @list = qw/ gait git grapefruit grassquit grit guitguit /;
+	my $ra = Regexp::Assemble->new;
+	# $ra->insert( split // ) for @list;
+	for my $l (@list) { $ra->insert( split //, $l ) }
+	$ra->_reduce;
+	is_deeply( $ra->_path,
+		[ 'g',
+			{
+				''  => undef,
+				'a' => ['a'],
+				'r' => ['r',
+					{
+						''  => undef,
+						'a' => ['a',
+							{
+								'p' => ['p','e','f','r'],
+								's' => ['s','s','q'],
+							},
+							'u',
+						],
+					},
+				],
+				'u' => [ 'u','i','t','g','u'],
+			},
+			'i', 't'
+		],
+		join( ' ', map { "/$_/" } @list ),
+	);
 }
 
 {
-    my @list = qw/ gait gambit gaslit giggit git godwit goldtit goodwillit
-        gowkit grapefruit grassquit grit guitguit /;
-    my $ra = Regexp::Assemble->new;
-    # $ra->insert( split // ) for @list;
-    for my $l (@list) { $ra->insert( split //, $l ) }
-    $ra->_reduce;
-    is_deeply( $ra->_path,
-        [ 'g',
-            {
-                'a' => [ 'a',
-                    {
-                        ''  => undef,
-                        'm' => ['m','b'],
-                        's' => ['s','l'],
-                    },
-                ],
-                'i' => [
-                    {
-                        ''  => undef,
-                        'i' => ['i','g','g'],
-                    }
-                ],
-                'o' => [ 'o',
-                    {
-                        'd' => ['d','w'],
-                        'l' => ['l','d','t'],
-                        'o' => ['o','d','w','i','l','l'],
-                        'w' => ['w','k'],
-                    }
-                ],
-                'r' => [ 'r',
-                    {
-                        ''  => undef,
-                        'a' => ['a',
-                            {
-                                'p' => ['p','e','f','r'],
-                                's' => ['s','s','q'],
-                            },
-                            'u',
-                        ],
-                    },
-                ],
-                'u' => [ 'u','i','t','g','u'],
-            },
-            'i', 't'
-        ],
-        join( ' ', map { "/$_/" } @list ),
-    );
+	my @list = qw/ gait gambit gaslit giggit git godwit goldtit goodwillit
+		gowkit grapefruit grassquit grit guitguit /;
+	my $ra = Regexp::Assemble->new;
+	# $ra->insert( split // ) for @list;
+	for my $l (@list) { $ra->insert( split //, $l ) }
+	$ra->_reduce;
+	is_deeply( $ra->_path,
+		[ 'g',
+			{
+				'a' => [ 'a',
+					{
+						''  => undef,
+						'm' => ['m','b'],
+						's' => ['s','l'],
+					},
+				],
+				'i' => [
+					{
+						''  => undef,
+						'i' => ['i','g','g'],
+					}
+				],
+				'o' => [ 'o',
+					{
+						'd' => ['d','w'],
+						'l' => ['l','d','t'],
+						'o' => ['o','d','w','i','l','l'],
+						'w' => ['w','k'],
+					}
+				],
+				'r' => [ 'r',
+					{
+						''  => undef,
+						'a' => ['a',
+							{
+								'p' => ['p','e','f','r'],
+								's' => ['s','s','q'],
+							},
+							'u',
+						],
+					},
+				],
+				'u' => [ 'u','i','t','g','u'],
+			},
+			'i', 't'
+		],
+		join( ' ', map { "/$_/" } @list ),
+	);
 }
 
 {
-    my @list = qw/ lit limit lid livid /;
-    my $ra = Regexp::Assemble->new;
-    # $ra->insert( split // ) for @list;
-    for my $l (@list) { $ra->insert( split //, $l ) }
-    $ra->_reduce;
-    is_deeply( $ra->_path,
-        [
-            'l','i', {
-                'm' => [
-                    {
-                        ''  => undef,
-                        'm' => ['m','i'],
-                    },
-                    't'
-                ],
-                'v' => [
-                    {
-                        ''  => undef,
-                        'v' => ['v','i'],
-                    },
-                    'd'
-                ],
-            },
-        ],
-        join( ' ', map { "/$_/" } @list ),
-    );
+	my @list = qw/ lit limit lid livid /;
+	my $ra = Regexp::Assemble->new;
+	# $ra->insert( split // ) for @list;
+	for my $l (@list) { $ra->insert( split //, $l ) }
+	$ra->_reduce;
+	is_deeply( $ra->_path,
+		[
+			'l','i', {
+				'm' => [
+					{
+						''  => undef,
+						'm' => ['m','i'],
+					},
+					't'
+				],
+				'v' => [
+					{
+						''  => undef,
+						'v' => ['v','i'],
+					},
+					'd'
+				],
+			},
+		],
+		join( ' ', map { "/$_/" } @list ),
+	);
 }
 
 {
-    my @list = qw/ theatre metre millimetre /;
-    my $ra = Regexp::Assemble->new;
-    # $ra->insert( split // ) for @list;
-    for my $l (@list) { $ra->insert( split //, $l ) }
-    $ra->_reduce;
-    is_deeply( $ra->_path,
-        [
-            {
-                'm' => [
-                    {
-                        ''  => undef,
-                        'm' => ['m','i','l','l','i'],
-                    },
-                    'm','e',
-                ],
-                't' => ['t','h','e','a'],
-            },
-            't','r','e'
-        ],
-        join( ' ', map { "/$_/" } @list ),
-    );
+	my @list = qw/ theatre metre millimetre /;
+	my $ra = Regexp::Assemble->new;
+	# $ra->insert( split // ) for @list;
+	for my $l (@list) { $ra->insert( split //, $l ) }
+	$ra->_reduce;
+	is_deeply( $ra->_path,
+		[
+			{
+				'm' => [
+					{
+						''  => undef,
+						'm' => ['m','i','l','l','i'],
+					},
+					'm','e',
+				],
+				't' => ['t','h','e','a'],
+			},
+			't','r','e'
+		],
+		join( ' ', map { "/$_/" } @list ),
+	);
 }
 
 {
-    my @list = qw/ sad salad spread/;
-    my $ra = Regexp::Assemble->new;
-    # $ra->insert( split // ) for @list;
-    for my $l (@list) { $ra->insert( split //, $l ) }
-    $ra->_reduce;
-    is_deeply( $ra->_path,
-        [
-            's',
-            {
-                'a' => [
-                    {
-                        ''  => undef,
-                        'a' => ['a','l'],
-                    },
-                ],
-                'p' => ['p','r','e'],
-            },
-            'a','d',
-        ],
-        join( ' ', map { "/$_/" } @list ),
-    );
+	my @list = qw/ sad salad spread/;
+	my $ra = Regexp::Assemble->new;
+	# $ra->insert( split // ) for @list;
+	for my $l (@list) { $ra->insert( split //, $l ) }
+	$ra->_reduce;
+	is_deeply( $ra->_path,
+		[
+			's',
+			{
+				'a' => [
+					{
+						''  => undef,
+						'a' => ['a','l'],
+					},
+				],
+				'p' => ['p','r','e'],
+			},
+			'a','d',
+		],
+		join( ' ', map { "/$_/" } @list ),
+	);
 }
 
 {
-    my @list = qw/ tough trough though thorough /;
-    my $ra = Regexp::Assemble->new;
-    # $ra->insert( split // ) for @list;
-    for my $l (@list) { $ra->insert( split //, $l ) }
-    $ra->_reduce;
-    is_deeply( $ra->_path,
-        [
-            't',
-            {
-                ''  => undef,
-                'h' => ['h',
-                    {
-                        ''  => undef,
-                        'o' => ['o','r'],
-                    }
-                ],
-                'r' => ['r'],
-            },
-            'o','u','g','h',
-        ],
-        join( ' ', map { "/$_/" } @list ),
-    );
+	my @list = qw/ tough trough though thorough /;
+	my $ra = Regexp::Assemble->new;
+	# $ra->insert( split // ) for @list;
+	for my $l (@list) { $ra->insert( split //, $l ) }
+	$ra->_reduce;
+	is_deeply( $ra->_path,
+		[
+			't',
+			{
+				''  => undef,
+				'h' => ['h',
+					{
+						''  => undef,
+						'o' => ['o','r'],
+					}
+				],
+				'r' => ['r'],
+			},
+			'o','u','g','h',
+		],
+		join( ' ', map { "/$_/" } @list ),
+	);
 }
 
 {
-    my @list = qw/ tough though trough through thorough /;
-    my $ra = Regexp::Assemble->new;
-    # $ra->insert( split // ) for @list;
-    for my $l (@list) { $ra->insert( split //, $l ) }
-    $ra->_reduce;
-    is_deeply( $ra->_path,
-        ['t',
-            {
-                ''  => undef,
-                h   => [ 'h',
-                    {
-                        o => [
-                            {
-                                '' => undef,
-                                o  => ['o','r']
-                            }
-                        ],
-                        r => ['r'],
-                    }
-                ],
-                r => ['r'],
-            },
-            'o','u','g','h'
-        ],
-        join( ' ', map { "/$_/" } @list ),
-    );
+	my @list = qw/ tough though trough through thorough /;
+	my $ra = Regexp::Assemble->new;
+	# $ra->insert( split // ) for @list;
+	for my $l (@list) { $ra->insert( split //, $l ) }
+	$ra->_reduce;
+	is_deeply( $ra->_path,
+		['t',
+			{
+				''  => undef,
+				h   => [ 'h',
+					{
+						o => [
+							{
+								'' => undef,
+								o  => ['o','r']
+							}
+						],
+						r => ['r'],
+					}
+				],
+				r => ['r'],
+			},
+			'o','u','g','h'
+		],
+		join( ' ', map { "/$_/" } @list ),
+	);
 }
 
 {
-    my @list = qw/ tit titanate titania titanite titano tite titi titian titien tittie /;
-    my $ra = Regexp::Assemble->new;
-    # $ra->insert( split // ) for @list;
-    for my $l (@list) { $ra->insert( split //, $l ) }
-    $ra->_reduce;
-    is_deeply( $ra->_path,
-        ['t','i','t',
-            {
-                ''  => undef,
-                'a' => [ 'a','n',
-                    {
-                        'a' => ['a','t','e'],
-                        'i' => ['i',
-                            {
-                                'a' => ['a'],
-                                't' => ['t','e']
-                            }
-                        ],
-                        'o' => ['o']
-                    }
-                ],
-                'i' => [ 'i',
-                    {
-                        ''  => undef,
-                        'a' => [
-                            {
-                                'e' => ['e'],
-                                'a' => ['a']
-                            },
-                            'n'
-                        ]
-                    }
-                ],
-                't' => [
-                    {
-                        ''  => undef,
-                        't' => ['t','i']
-                    },
-                    'e'
-                ]
-            }
-        ],
-        join( ' ', map { "/$_/" } @list ),
-    );
+	my @list = qw/ tit titanate titania titanite titano tite titi titian titien tittie /;
+	my $ra = Regexp::Assemble->new;
+	# $ra->insert( split // ) for @list;
+	for my $l (@list) { $ra->insert( split //, $l ) }
+	$ra->_reduce;
+	is_deeply( $ra->_path,
+		['t','i','t',
+			{
+				''  => undef,
+				'a' => [ 'a','n',
+					{
+						'a' => ['a','t','e'],
+						'i' => ['i',
+							{
+								'a' => ['a'],
+								't' => ['t','e']
+							}
+						],
+						'o' => ['o']
+					}
+				],
+				'i' => [ 'i',
+					{
+						''  => undef,
+						'a' => [
+							{
+								'e' => ['e'],
+								'a' => ['a']
+							},
+							'n'
+						]
+					}
+				],
+				't' => [
+					{
+						''  => undef,
+						't' => ['t','i']
+					},
+					'e'
+				]
+			}
+		],
+		join( ' ', map { "/$_/" } @list ),
+	);
 }
 
 {
-    my $ra = Regexp::Assemble->new;
-    $ra->add( 'dasin' );
-    $ra->add( 'dosin' );
-    $ra->add( 'dastin' );
-    $ra->add( 'dostin' );
+	my $ra = Regexp::Assemble->new;
+	$ra->add( 'dasin' );
+	$ra->add( 'dosin' );
+	$ra->add( 'dastin' );
+	$ra->add( 'dostin' );
 
-    $ra->_reduce;
-    is_deeply( $ra->_path,
-        [
-            'd',
-            {
-                'a' =>['a'],
-                'o' =>['o'],
-            },
-            's',
-            {
-                ''  => undef,
-                't' => ['t'],
-            },
-            'i', 'n',
-        ],
-        'dasin/dosin/dastin/dosting'
-    ) or diag ($ra->_path);
+	$ra->_reduce;
+	is_deeply( $ra->_path,
+		[
+			'd',
+			{
+				'a' =>['a'],
+				'o' =>['o'],
+			},
+			's',
+			{
+				''  => undef,
+				't' => ['t'],
+			},
+			'i', 'n',
+		],
+		'dasin/dosin/dastin/dosting'
+	) or diag ($ra->_path);
 }
 
 is( $_, $fixed, '$_ has not been altered' );

--- a/t/03_str.t
+++ b/t/03_str.t
@@ -9,9 +9,9 @@ use strict;
 
 eval qq{use Test::More tests => 210};
 if( $@ ) {
-    warn "# Test::More not available, no tests performed\n";
-    print "1..1\nok 1\n";
-    exit 0;
+	warn "# Test::More not available, no tests performed\n";
+	print "1..1\nok 1\n";
+	exit 0;
 }
 
 use Regexp::Assemble;
@@ -22,327 +22,327 @@ $_ = $fixed;
 is( Regexp::Assemble->new->as_string, $Regexp::Assemble::Always_Fail, 'empty' );
 
 for my $test (
-    [ '(?:)?',       [''] ],
-    [ 'd',           ['d'] ],
-    [ 'dot',         ['d', 'o', 't'] ],
-    [ '[dot]',       ['d'], ['o'], ['t'] ],
-    [ 'd?',          ['d'], [''] ],
-    [ 'da',          ['d', 'a'] ],
-    [ 'da?',         ['d', 'a'], ['d'] ],
-    [ '(?:da)?',     ['d', 'a'], [''] ],
-    [ '[ad]?',       ['d'], [''], ['a'] ],
-    [ '(?:do|a)?',   ['d', 'o'], [''], ['a'] ],
-    [ '.',           ['x'], ['.'] ],
-    [ '.',           ['\033'], ['.'] ],
-    [ '.',           ['\\d'], ['\\s'], ['.'] ],
-    [ '.',           ['\\d'], ['\\D'] ],
-    [ '.',           ['\\s'], ['\\S'] ],
-    [ '.',           ['\\w'], ['\\W'] ],
-    [ '.',           ['\\w'], ['\\W'], ["\t"] ],
-    [ '\\d',         ['\\d'], ['5'] ],
-    [ '\\d',         ['\\d'], [5], [7], [0] ],
-    [ '\\d?',        ['\\d'], ['5'], [''] ],
-    [ '\\s',         ['\\s'], [' '] ],
-    [ '\\s?',        ['\\s'], [''] ],
-    [ '[\\dx]',      ['\\d'], [5], [7], [0], ['x'] ],
-    [ '[\\d\\s]',    ['\\d'], ['\\s'], [5], [7], [0], [' '] ],
-    [ '[.p]',        ['\\.'], ['p'] ],
-    [ '\\w',         ['\\w'], [5], [1], [0], ['a'], ['_'] ],
-    [ '[*\\d]?',     ['\\d'], [''], ['\\*'] ],
-    [ '[\\d^]?',     ['\\d'], [''], ['\\^'] ],
-    [ 'a[?@]z',      ['a', '@', 'z'], ['a', "\?", 'z'] ],
-    [ '\\+',         ['\\+'] ],
-    [ '\\+',         [quotemeta('+')] ],
-    [ '[*+]',        ['\\+'], ['\\*'] ],
-    [ '[*+]',        [quotemeta('+')], [quotemeta('*')] ],
-    [ '[-0z]',       ['-'], ['0'], ['z'] ],
-    [ '[-.z]',       ['-'], ['\\.'], ['z'] ],
-    [ '[-*+]',       ['\\+'], ['-'], ['\\*'] ],
-    [ '[-.]',        ['\\.'], ['-'] ],
-    [ '(?:[0z]|^)',  ['^'], ['0'], ['z'] ],
-    [ '(?:[-0z]|^)', ['^'], ['0'], ['-'], ['z'] ],
-    [ '(?:[-\\w]|^)', ['^'], ['0'], ['-'], ['z'], ['\\w'] ],
-    [ '(?:[-0]|$)',   ['$'], ['0'], ['-'] ],
-    [ '(?:[-0]|$|^)', ['$'], ['0'], ['-'], ['^'] ],
-    [ '\\d',          [0], [1], [2], [3], [4], [5], [6], [7], [8], [9] ],
-    [ '[\\dx]',       [0], [1], [2], [3], [4], [5], [6], [7], [8], [9], ['x'] ],
-    [ '(?:b[ey])?',   ['b', 'e'], [''], ['b', 'y'] ],
-    [ '(?:be|do)?',   ['b', 'e'], [''], ['d', 'o'] ],
-    [ '(?:b[ey]|a)?', ['b', 'e'], [''], ['b', 'y'], ['a'] ],
-    [ 'da[by]',       [qw(d a b)], [qw(d a y)] ],
-    [ 'da(?:ily|b)',  [qw(d a b)], [qw(d a i l y)] ],
-    [ '(?:night|day)',    [qw(n i g h t)], [qw(d a y)] ],
-    [ 'da(?:(?:il)?y|b)', [qw(d a b)], [qw(d a y)], [qw(d a i l y)] ],
-    [ 'dab(?:ble)?',      [qw(d a b)], [qw(d a b b l e)] ],
-    [ 'd(?:o(?:ne?)?)?',      [qw(d)], [qw(d o)], [qw(d o n)], [qw(d o n e)] ],
-    [ '(?:d(?:o(?:ne?)?)?)?', [qw(d)], [qw(d o)], [qw(d o n)], [qw(d o n e)], [''] ],
-    [ 'd(?:o[begnt]|u[bd])',
-        [qw(d o b)], [qw(d o e)], [qw(d o g)], [qw(d o n)], [qw(d o t)], [qw(d u b)], [qw(d u d)] ],
-    [ 'da(?:m[ep]|r[kt])',
-        [qw(d a m p)], [qw(d a m e)], [qw(d a r t)], [qw(d a r k)] ],
+	[ '(?:)?',       [''] ],
+	[ 'd',           ['d'] ],
+	[ 'dot',         ['d', 'o', 't'] ],
+	[ '[dot]',       ['d'], ['o'], ['t'] ],
+	[ 'd?',          ['d'], [''] ],
+	[ 'da',          ['d', 'a'] ],
+	[ 'da?',         ['d', 'a'], ['d'] ],
+	[ '(?:da)?',     ['d', 'a'], [''] ],
+	[ '[ad]?',       ['d'], [''], ['a'] ],
+	[ '(?:do|a)?',   ['d', 'o'], [''], ['a'] ],
+	[ '.',           ['x'], ['.'] ],
+	[ '.',           ['\033'], ['.'] ],
+	[ '.',           ['\\d'], ['\\s'], ['.'] ],
+	[ '.',           ['\\d'], ['\\D'] ],
+	[ '.',           ['\\s'], ['\\S'] ],
+	[ '.',           ['\\w'], ['\\W'] ],
+	[ '.',           ['\\w'], ['\\W'], ["\t"] ],
+	[ '\\d',         ['\\d'], ['5'] ],
+	[ '\\d',         ['\\d'], [5], [7], [0] ],
+	[ '\\d?',        ['\\d'], ['5'], [''] ],
+	[ '\\s',         ['\\s'], [' '] ],
+	[ '\\s?',        ['\\s'], [''] ],
+	[ '[\\dx]',      ['\\d'], [5], [7], [0], ['x'] ],
+	[ '[\\d\\s]',    ['\\d'], ['\\s'], [5], [7], [0], [' '] ],
+	[ '[.p]',        ['\\.'], ['p'] ],
+	[ '\\w',         ['\\w'], [5], [1], [0], ['a'], ['_'] ],
+	[ '[*\\d]?',     ['\\d'], [''], ['\\*'] ],
+	[ '[\\d^]?',     ['\\d'], [''], ['\\^'] ],
+	[ 'a[?@]z',      ['a', '@', 'z'], ['a', "\?", 'z'] ],
+	[ '\\+',         ['\\+'] ],
+	[ '\\+',         [quotemeta('+')] ],
+	[ '[*+]',        ['\\+'], ['\\*'] ],
+	[ '[*+]',        [quotemeta('+')], [quotemeta('*')] ],
+	[ '[-0z]',       ['-'], ['0'], ['z'] ],
+	[ '[-.z]',       ['-'], ['\\.'], ['z'] ],
+	[ '[-*+]',       ['\\+'], ['-'], ['\\*'] ],
+	[ '[-.]',        ['\\.'], ['-'] ],
+	[ '(?:[0z]|^)',  ['^'], ['0'], ['z'] ],
+	[ '(?:[-0z]|^)', ['^'], ['0'], ['-'], ['z'] ],
+	[ '(?:[-\\w]|^)', ['^'], ['0'], ['-'], ['z'], ['\\w'] ],
+	[ '(?:[-0]|$)',   ['$'], ['0'], ['-'] ],
+	[ '(?:[-0]|$|^)', ['$'], ['0'], ['-'], ['^'] ],
+	[ '\\d',          [0], [1], [2], [3], [4], [5], [6], [7], [8], [9] ],
+	[ '[\\dx]',       [0], [1], [2], [3], [4], [5], [6], [7], [8], [9], ['x'] ],
+	[ '(?:b[ey])?',   ['b', 'e'], [''], ['b', 'y'] ],
+	[ '(?:be|do)?',   ['b', 'e'], [''], ['d', 'o'] ],
+	[ '(?:b[ey]|a)?', ['b', 'e'], [''], ['b', 'y'], ['a'] ],
+	[ 'da[by]',       [qw(d a b)], [qw(d a y)] ],
+	[ 'da(?:ily|b)',  [qw(d a b)], [qw(d a i l y)] ],
+	[ '(?:night|day)',    [qw(n i g h t)], [qw(d a y)] ],
+	[ 'da(?:(?:il)?y|b)', [qw(d a b)], [qw(d a y)], [qw(d a i l y)] ],
+	[ 'dab(?:ble)?',      [qw(d a b)], [qw(d a b b l e)] ],
+	[ 'd(?:o(?:ne?)?)?',      [qw(d)], [qw(d o)], [qw(d o n)], [qw(d o n e)] ],
+	[ '(?:d(?:o(?:ne?)?)?)?', [qw(d)], [qw(d o)], [qw(d o n)], [qw(d o n e)], [''] ],
+	[ 'd(?:o[begnt]|u[bd])',
+		[qw(d o b)], [qw(d o e)], [qw(d o g)], [qw(d o n)], [qw(d o t)], [qw(d u b)], [qw(d u d)] ],
+	[ 'da(?:m[ep]|r[kt])',
+		[qw(d a m p)], [qw(d a m e)], [qw(d a r t)], [qw(d a r k)] ],
 ) {
-    my $result = shift @$test;
-    my $r = Regexp::Assemble->new;
-    $r->insert(@$_) for @$test;
-    my $args = join( ') (', map {join('', @$_)} @$test );
-    is( $r->as_string, $result, "insert ($args)")
-        or diag( Regexp::Assemble::_dump([@$test]) );
+	my $result = shift @$test;
+	my $r = Regexp::Assemble->new;
+	$r->insert(@$_) for @$test;
+	my $args = join( ') (', map {join('', @$_)} @$test );
+	is( $r->as_string, $result, "insert ($args)")
+		or diag( Regexp::Assemble::_dump([@$test]) );
 }
 
 my $xism = ($] < 5.013) ? '-xism' : '^';
 
 for my $test (
-    [ qq'(?$xism:(?:^|m)a)',    qw(^a ma) ],
-    [ qq'(?$xism:(?:[mw]|^)a)', qw(^a ma wa) ],
-    [ qq'(?$xism:(?:^|\\^)a)',  qw(^a), '\\^a' ],
-    [ qq'(?$xism:(?:^|0)a)',    qw(^a 0a) ],
-    [ qq'(?$xism:(?:[m^]|^)a)', qw(^a ma), '\\^a' ],
-    [ qq'(?$xism:(?:ma|^)a)',   qw(^a maa) ],
-    [ qq'(?$xism:a.+)',         qw(a.+) ],
-    [ qq'(?$xism:b?)',          '[b]?' ],
-    [ qq'(?$xism:\\.)',         '[.]' ],
-    [ qq'(?$xism:\\.+)',        '[.]+' ],
-    [ qq'(?$xism:\\.+)'  ,      '[\\.]+' ],
-    [ qq'(?$xism:\\^+)',        '[\\^]+' ],
-    [ qq'(?$xism:%)',           '[%]' ],
-    [ qq'(?$xism:%)',           '[\\%]' ],
-    [ qq'(?$xism:!)',           '[!]' ],
-    [ qq'(?$xism:!)',           '[\\!]' ],
-    [ qq'(?$xism:@)',           '[@]' ],
-    [ qq'(?$xism:@)',           '[\\@]' ],
-    [ qq'(?$xism:a|[bc])',      'a|[bc]' ],
-    [ qq'(?$xism:ad?|[bc])',    'ad?|[bc]' ],
-    [ qq'(?$xism:'.'b(?:$|e))',    qw(b$ be) ],
-    [ qq'(?$xism:'.'b(?:[ae]|$))', qw(b$ be ba) ],
-    [ qq'(?$xism:'.'b(?:$|\\$))',  qw(b$), 'b\\$' ],
-    [ qq'(?$xism:(?:^a[bc]|de))',  qw(^ab ^ac de) ],
-    [ qq'(?$xism:(?i:/))',              qw(/),          {flags => 'i'} ],
-    [ qq'(?$xism:(?i:(?:^a[bc]|de)))',  qw(^ab ^ac de), {flags => 'i'} ],
-    [ qq'(?$xism:(?im:(?:^a[bc]|de)))', qw(^ab ^ac de), {flags => 'im'} ],
-    [ qq'(?$xism:a(?:%[de]|=[bc]))',
-        quotemeta('a%d'), quotemeta('a=b'), quotemeta('a%e'), quotemeta('a=c') ],
-    [ qq'(?$xism:\\^[,:])',     quotemeta('^:'), quotemeta('^,') ],
-    [ qq'(?$xism:a[-*=])',      quotemeta('a='), quotemeta('a*'), quotemeta('a-') ],
-    [ qq'(?$xism:l(?:im)?it)',  qw(lit limit) ],
-    [ qq'(?$xism:a(?:(?:g[qr]|h)w|[de]n|m)z)', qw(amz adnz aenz agrwz agqwz ahwz) ],
-    [ qq'(?$xism:a(?:(?:e(?:[gh]u|ft)|dkt|f)w|(?:(?:ij|g)m|hn)v)z)',
-        qw(adktwz aeftwz aeguwz aehuwz afwz agmvz ahnvz aijmvz) ],
-    [ qq'(?$xism:b(?:d(?:kt?|i)|ckt?)x)', qw(bcktx bckx bdix bdktx bdkx) ],
-    [ qq'(?$xism:d(?:[ln]dr?t|x))',  qw(dldrt dndrt dldt dndt dx) ],
-    [ qq'(?$xism:d(?:[ln][dp]t|x))', qw(dldt dndt dlpt dnpt dx) ],
-    [ qq'(?$xism:d(?:[ln][dp][mr]t|x))', qw(dldrt dndrt dldmt dndmt dlprt dnprt dlpmt dnpmt dx) ],
-    [ qq'(?$xism:'.'(?:\(scan|\*mens|\[mail))', '\\*mens', '\\(scan', '\\[mail'],
-    [ qq'(?$xism:a\\[b\\[c)', '\\Qa[b[c' ],
-    [ qq'(?$xism:a\\]b\\]c)', '\\Qa]b]c' ],
-    [ qq'(?$xism:a\\(b\\(c)', '\\Qa(b(c' ],
-    [ qq'(?$xism:a\\)b\\)c)', '\\Qa)b)c' ],
-    [ qq'(?$xism:a[(+[]b)', '\\Qa(b', '\\Qa[b', '\\Qa+b' ],
-    [ qq'(?$xism:a[-+^]b)', '\\Qa^b', '\\Qa-b', '\\Qa+b' ],
-    [ qq'(?$xism:car(?:rot)?)', qw(car carrot), {lookahead => 1} ],
-    [ qq'(?$xism:car[dpt]?)',   qw(car cart card carp), {lookahead => 1} ],
-    [ qq'(?$xism:[bc]a[nr]e)',  qw(bane bare cane care), {lookahead => 1} ],
-    [ qq'(?$xism:(?=[ru])(?:ref)?use)',       qw(refuse use), {lookahead => 1} ],
-    [ qq'(?$xism:(?=[bcd])(?:bird|cat|dog))', qw(bird cat dog), {lookahead => 1} ],
-    [ qq'(?$xism:sea(?=[hs])(?:horse|son))',  qw(seahorse season), {lookahead => 1} ],
-    [ qq'(?$xism:car(?:(?=[dr])(?:rot|d))?)', qw(car card carrot), {lookahead => 1} ],
-    [ qq'(?$xism:(?:(?:[hl]o|s?t|ch)o|[bf]a)ked)',
-        qw(looked choked hooked stoked toked baked faked) ],
-    [ qq'(?$xism:(?=[frt])(?:trans|re|f)action)',
-        qw(faction reaction transaction), {lookahead => 1} ],
-    [ qq'(?$xism:c(?=[ao])(?:or(?=[np])(?:pse|n)|ar(?=[de])(?:et|d)))',
-        qw(card caret corn corpse), {lookahead => 1} ],
-    [ qq'(?$xism:car(?:(?=[dipt])(?:[dpt]|i(?=[no])(?:ng|on)))?)',
-        qw(car cart card carp carion caring), {lookahead => 1} ],
-    [ qq'(?$xism:(?=[dfrst])(?:(?=[frt])(?:trans|re|f)a|(?=[ds])(?:dir|s)e)ction)',
-        qw(faction reaction transaction direction section), {lookahead => 1} ],
-    [ qq'(?$xism:car(?=[eir])(?:e(?=[flst])(?:(?=[ls])(?:le)?ss|ful|t)|i(?=[no])(?:ng|on)|r(?=[iy])(?:ied|y)))',
-        qw(caret caress careful careless caring carion carry carried), {lookahead => 1} ],
-    [ qq'(?$xism:(?=[uv])(?:u(?=[nr])(?:n(?=[iprs])(?:(?=[ip])(?:(?:p[or]|impr))?i|(?:sea)?|rea)|r)|v(?=[ei])(?:en(?=[it])(?:trime|i)|i))son)',
-        qw(unimprison unison unpoison unprison unreason unseason unson urson venison ventrimeson vison), {lookahead => 1} ],
-    [ qq'(?$xism:(?:a?bc?)?d)',         qw(abcd abd bcd bd d) ],
-    [ qq'(?$xism:(?:a?bc?|c)d)',        qw(abcd abd bcd bd cd) ],
-    [ qq'(?$xism:(?:(?:a?bc?)?d|c))',   qw(abcd abd bcd bd c d) ],
-    [ qq'(?$xism:(?:(?:a?bc?)?d|cd?))', qw(abcd abd bcd bd c cd d) ],
-    [ qq'(?$xism:(?:(?:ab?|b)c?)?d)',   qw(abcd abd acd ad bcd bd d) ],
-    [ qq'(?$xism:(?:(?:ab)?cd?)?e)',          qw(abcde abce cde ce e) ],
-    [ qq'(?$xism:(?:(?:(?:ab?|b)c?)?d|c))',   qw(abcd abd acd ad bcd bd c d) ],
-    [ qq'(?$xism:(?:(?:(?:ab?|b)c?)?d|cd?))', qw(abcd abd acd ad bcd bd c cd d) ],
-    [ qq'(?$xism:'.'^(?:b?cd?|ab)$)',          qw(^ab$ ^bc$ ^bcd$ ^c$ ^cd$) ],
-    [ qq'(?$xism:'.'^(?:(?:ab?c|cd?)e?|e)$)',  qw(^abc$ ^abce$ ^ac$ ^ace$ ^c$ ^cd$ ^cde$ ^ce$ ^e$) ],
-    [ qq'(?$xism:'.'^(?:abc|bcd)e?$)',         qw(^abc$ ^abce$ ^bcd$ ^bcde$) ],
-    [ qq'(?$xism:'.'^(?:abcdef|bcdefg)h?$)',   qw(^abcdef$ ^abcdefh$ ^bcdefg$ ^bcdefgh$) ],
-    [ qq'(?$xism:'.'^(?:bcdefg|abcd)h?$)',     qw(^abcd$ ^abcdh$ ^bcdefg$ ^bcdefgh$) ],
-    [ qq'(?$xism:'.'^(?:abcdef|bcd)h?$)',      qw(^abcdef$ ^abcdefh$ ^bcd$ ^bcdh$) ],
-    [ qq'(?$xism:'.'^(?:a(?:bcd|cd?)e?|e)$)',  qw(^abcd$ ^abcde$ ^ac$ ^acd$ ^acde$ ^ace$ ^e$) ],
-    [ qq'(?$xism:'.'^(?:bcd|cd?)e?$)',         qw(^bcd$ ^bcde$ ^c$ ^cd$ ^cde$ ^ce$) ],
-    [ qq'(?$xism:'.'^(?:abc|bc?)(?:de)?$)',    qw(^abc$ ^abcde$ ^b$ ^bc$ ^bcde$ ^bde$) ],
-    [ qq'(?$xism:'.'^(?:b(?:cd)?|abd)e?$)',    qw(^abd$ ^abde$ ^b$ ^bcd$ ^bcde$ ^be$) ],
-    [ qq'(?$xism:'.'^(?:ad?|bcd)e?$)',         qw(^a$ ^ad$ ^ade$ ^ae$ ^bcd$ ^bcde$) ],
-    [ qq'(?$xism:'.'^(?:a(?:bcd|cd?)e?|de)$)', qw(^abcd$ ^abcde$ ^ac$ ^acd$ ^acde$ ^ace$ ^de$) ],
-    [ qq'(?$xism:'.'^(?:a(?:bcde)?|bc?d?e)$)', qw(^a$ ^abcde$ ^bcde$ ^bce$ ^bde$ ^be$) ],
-    [ qq'(?$xism:'.'^(?:a(?:b[cd]?)?|bd?e?f)$)', qw(^a$ ^ab$ ^abc$ ^abd$ ^bdef$ ^bdf$ ^bef$ ^bf$) ],
-    [ qq'(?$xism:'.'^(?:a(?:bc?|dd)?|bd?e?f)$)', qw(^a$ ^ab$ ^abc$ ^add$ ^bdef$ ^bdf$ ^bef$ ^bf$) ],
-    [ qq'(?$xism:'.'^(?:a(?:bc?|de)?|bc?d?f)$)', qw(^a$ ^ab$ ^abc$ ^ade$ ^bcdf$ ^bcf$ ^bdf$ ^bf$) ],
-    [ qq'(?$xism:'.'^(?:a(?:bc?|de)?|cd?e?f)$)', qw(^a$ ^ab$ ^abc$ ^ade$ ^cdef$ ^cdf$ ^cef$ ^cf$) ],
-    [ qq'(?$xism:'.'^(?:a(?:bc?|e)?|bc?de?f)$)', qw(^a$ ^ab$ ^abc$ ^ae$ ^bcdef$ ^bcdf$ ^bdef$ ^bdf$) ],
-    [ qq'(?$xism:'.'^(?:a(?:bc?|e)?|b(?:cd)?e?f)$)', qw(^a$ ^ab$ ^abc$ ^ae$ ^bcdef$ ^bcdf$ ^bef$ ^bf$) ],
-    [ qq'(?$xism:'.'^(?:b(?:cde?|d?e)f|a(?:bc?|e)?)$)',
-        qw(^a$ ^ab$ ^abc$ ^ae$ ^bcdef$ ^bcdf$ ^bdef$ ^bef$) ],
-    [ qq'(?$xism:\\b(?:c[de]|ab)\\b)', qw(ab cd ce), {anchor_word => 1} ],
-    [ qq'(?$xism:\\b(?:c[de]|ab))',    qw(ab cd ce), {anchor_word_begin => 1} ],
-    [ qq'(?$xism:'.'^(?:c[de]|ab)$)',     qw(ab cd ce), {anchor_line => 1} ],
-    [ qq'(?$xism:(?:c[de]|ab))',       qw(ab cd ce), {anchor_line => 0} ],
-    [ qq'(?$xism:'.'(?:c[de]|ab)$)',      qw(ab cd ce), {anchor_line_end => 1} ],
-    [ qq'(?$xism:\\A(?:c[de]|ab)\\Z)', qw(ab cd ce), {anchor_string => 1} ],
-    [ qq'(?$xism:(?:c[de]|ab))',       qw(ab cd ce), {anchor_string => 0} ],
-    [ qq'(?$xism:x[[:punct:]][yz])',   qw(x[[:punct:]]y x[[:punct:]]z) ],
+	[ qq'(?$xism:(?:^|m)a)',    qw(^a ma) ],
+	[ qq'(?$xism:(?:[mw]|^)a)', qw(^a ma wa) ],
+	[ qq'(?$xism:(?:^|\\^)a)',  qw(^a), '\\^a' ],
+	[ qq'(?$xism:(?:^|0)a)',    qw(^a 0a) ],
+	[ qq'(?$xism:(?:[m^]|^)a)', qw(^a ma), '\\^a' ],
+	[ qq'(?$xism:(?:ma|^)a)',   qw(^a maa) ],
+	[ qq'(?$xism:a.+)',         qw(a.+) ],
+	[ qq'(?$xism:b?)',          '[b]?' ],
+	[ qq'(?$xism:\\.)',         '[.]' ],
+	[ qq'(?$xism:\\.+)',        '[.]+' ],
+	[ qq'(?$xism:\\.+)'  ,      '[\\.]+' ],
+	[ qq'(?$xism:\\^+)',        '[\\^]+' ],
+	[ qq'(?$xism:%)',           '[%]' ],
+	[ qq'(?$xism:%)',           '[\\%]' ],
+	[ qq'(?$xism:!)',           '[!]' ],
+	[ qq'(?$xism:!)',           '[\\!]' ],
+	[ qq'(?$xism:@)',           '[@]' ],
+	[ qq'(?$xism:@)',           '[\\@]' ],
+	[ qq'(?$xism:a|[bc])',      'a|[bc]' ],
+	[ qq'(?$xism:ad?|[bc])',    'ad?|[bc]' ],
+	[ qq'(?$xism:'.'b(?:$|e))',    qw(b$ be) ],
+	[ qq'(?$xism:'.'b(?:[ae]|$))', qw(b$ be ba) ],
+	[ qq'(?$xism:'.'b(?:$|\\$))',  qw(b$), 'b\\$' ],
+	[ qq'(?$xism:(?:^a[bc]|de))',  qw(^ab ^ac de) ],
+	[ qq'(?$xism:(?i:/))',              qw(/),          {flags => 'i'} ],
+	[ qq'(?$xism:(?i:(?:^a[bc]|de)))',  qw(^ab ^ac de), {flags => 'i'} ],
+	[ qq'(?$xism:(?im:(?:^a[bc]|de)))', qw(^ab ^ac de), {flags => 'im'} ],
+	[ qq'(?$xism:a(?:%[de]|=[bc]))',
+		quotemeta('a%d'), quotemeta('a=b'), quotemeta('a%e'), quotemeta('a=c') ],
+	[ qq'(?$xism:\\^[,:])',     quotemeta('^:'), quotemeta('^,') ],
+	[ qq'(?$xism:a[-*=])',      quotemeta('a='), quotemeta('a*'), quotemeta('a-') ],
+	[ qq'(?$xism:l(?:im)?it)',  qw(lit limit) ],
+	[ qq'(?$xism:a(?:(?:g[qr]|h)w|[de]n|m)z)', qw(amz adnz aenz agrwz agqwz ahwz) ],
+	[ qq'(?$xism:a(?:(?:e(?:[gh]u|ft)|dkt|f)w|(?:(?:ij|g)m|hn)v)z)',
+		qw(adktwz aeftwz aeguwz aehuwz afwz agmvz ahnvz aijmvz) ],
+	[ qq'(?$xism:b(?:d(?:kt?|i)|ckt?)x)', qw(bcktx bckx bdix bdktx bdkx) ],
+	[ qq'(?$xism:d(?:[ln]dr?t|x))',  qw(dldrt dndrt dldt dndt dx) ],
+	[ qq'(?$xism:d(?:[ln][dp]t|x))', qw(dldt dndt dlpt dnpt dx) ],
+	[ qq'(?$xism:d(?:[ln][dp][mr]t|x))', qw(dldrt dndrt dldmt dndmt dlprt dnprt dlpmt dnpmt dx) ],
+	[ qq'(?$xism:'.'(?:\(scan|\*mens|\[mail))', '\\*mens', '\\(scan', '\\[mail'],
+	[ qq'(?$xism:a\\[b\\[c)', '\\Qa[b[c' ],
+	[ qq'(?$xism:a\\]b\\]c)', '\\Qa]b]c' ],
+	[ qq'(?$xism:a\\(b\\(c)', '\\Qa(b(c' ],
+	[ qq'(?$xism:a\\)b\\)c)', '\\Qa)b)c' ],
+	[ qq'(?$xism:a[(+[]b)', '\\Qa(b', '\\Qa[b', '\\Qa+b' ],
+	[ qq'(?$xism:a[-+^]b)', '\\Qa^b', '\\Qa-b', '\\Qa+b' ],
+	[ qq'(?$xism:car(?:rot)?)', qw(car carrot), {lookahead => 1} ],
+	[ qq'(?$xism:car[dpt]?)',   qw(car cart card carp), {lookahead => 1} ],
+	[ qq'(?$xism:[bc]a[nr]e)',  qw(bane bare cane care), {lookahead => 1} ],
+	[ qq'(?$xism:(?=[ru])(?:ref)?use)',       qw(refuse use), {lookahead => 1} ],
+	[ qq'(?$xism:(?=[bcd])(?:bird|cat|dog))', qw(bird cat dog), {lookahead => 1} ],
+	[ qq'(?$xism:sea(?=[hs])(?:horse|son))',  qw(seahorse season), {lookahead => 1} ],
+	[ qq'(?$xism:car(?:(?=[dr])(?:rot|d))?)', qw(car card carrot), {lookahead => 1} ],
+	[ qq'(?$xism:(?:(?:[hl]o|s?t|ch)o|[bf]a)ked)',
+		qw(looked choked hooked stoked toked baked faked) ],
+	[ qq'(?$xism:(?=[frt])(?:trans|re|f)action)',
+		qw(faction reaction transaction), {lookahead => 1} ],
+	[ qq'(?$xism:c(?=[ao])(?:or(?=[np])(?:pse|n)|ar(?=[de])(?:et|d)))',
+		qw(card caret corn corpse), {lookahead => 1} ],
+	[ qq'(?$xism:car(?:(?=[dipt])(?:[dpt]|i(?=[no])(?:ng|on)))?)',
+		qw(car cart card carp carion caring), {lookahead => 1} ],
+	[ qq'(?$xism:(?=[dfrst])(?:(?=[frt])(?:trans|re|f)a|(?=[ds])(?:dir|s)e)ction)',
+		qw(faction reaction transaction direction section), {lookahead => 1} ],
+	[ qq'(?$xism:car(?=[eir])(?:e(?=[flst])(?:(?=[ls])(?:le)?ss|ful|t)|i(?=[no])(?:ng|on)|r(?=[iy])(?:ied|y)))',
+		qw(caret caress careful careless caring carion carry carried), {lookahead => 1} ],
+	[ qq'(?$xism:(?=[uv])(?:u(?=[nr])(?:n(?=[iprs])(?:(?=[ip])(?:(?:p[or]|impr))?i|(?:sea)?|rea)|r)|v(?=[ei])(?:en(?=[it])(?:trime|i)|i))son)',
+		qw(unimprison unison unpoison unprison unreason unseason unson urson venison ventrimeson vison), {lookahead => 1} ],
+	[ qq'(?$xism:(?:a?bc?)?d)',         qw(abcd abd bcd bd d) ],
+	[ qq'(?$xism:(?:a?bc?|c)d)',        qw(abcd abd bcd bd cd) ],
+	[ qq'(?$xism:(?:(?:a?bc?)?d|c))',   qw(abcd abd bcd bd c d) ],
+	[ qq'(?$xism:(?:(?:a?bc?)?d|cd?))', qw(abcd abd bcd bd c cd d) ],
+	[ qq'(?$xism:(?:(?:ab?|b)c?)?d)',   qw(abcd abd acd ad bcd bd d) ],
+	[ qq'(?$xism:(?:(?:ab)?cd?)?e)',          qw(abcde abce cde ce e) ],
+	[ qq'(?$xism:(?:(?:(?:ab?|b)c?)?d|c))',   qw(abcd abd acd ad bcd bd c d) ],
+	[ qq'(?$xism:(?:(?:(?:ab?|b)c?)?d|cd?))', qw(abcd abd acd ad bcd bd c cd d) ],
+	[ qq'(?$xism:'.'^(?:b?cd?|ab)$)',          qw(^ab$ ^bc$ ^bcd$ ^c$ ^cd$) ],
+	[ qq'(?$xism:'.'^(?:(?:ab?c|cd?)e?|e)$)',  qw(^abc$ ^abce$ ^ac$ ^ace$ ^c$ ^cd$ ^cde$ ^ce$ ^e$) ],
+	[ qq'(?$xism:'.'^(?:abc|bcd)e?$)',         qw(^abc$ ^abce$ ^bcd$ ^bcde$) ],
+	[ qq'(?$xism:'.'^(?:abcdef|bcdefg)h?$)',   qw(^abcdef$ ^abcdefh$ ^bcdefg$ ^bcdefgh$) ],
+	[ qq'(?$xism:'.'^(?:bcdefg|abcd)h?$)',     qw(^abcd$ ^abcdh$ ^bcdefg$ ^bcdefgh$) ],
+	[ qq'(?$xism:'.'^(?:abcdef|bcd)h?$)',      qw(^abcdef$ ^abcdefh$ ^bcd$ ^bcdh$) ],
+	[ qq'(?$xism:'.'^(?:a(?:bcd|cd?)e?|e)$)',  qw(^abcd$ ^abcde$ ^ac$ ^acd$ ^acde$ ^ace$ ^e$) ],
+	[ qq'(?$xism:'.'^(?:bcd|cd?)e?$)',         qw(^bcd$ ^bcde$ ^c$ ^cd$ ^cde$ ^ce$) ],
+	[ qq'(?$xism:'.'^(?:abc|bc?)(?:de)?$)',    qw(^abc$ ^abcde$ ^b$ ^bc$ ^bcde$ ^bde$) ],
+	[ qq'(?$xism:'.'^(?:b(?:cd)?|abd)e?$)',    qw(^abd$ ^abde$ ^b$ ^bcd$ ^bcde$ ^be$) ],
+	[ qq'(?$xism:'.'^(?:ad?|bcd)e?$)',         qw(^a$ ^ad$ ^ade$ ^ae$ ^bcd$ ^bcde$) ],
+	[ qq'(?$xism:'.'^(?:a(?:bcd|cd?)e?|de)$)', qw(^abcd$ ^abcde$ ^ac$ ^acd$ ^acde$ ^ace$ ^de$) ],
+	[ qq'(?$xism:'.'^(?:a(?:bcde)?|bc?d?e)$)', qw(^a$ ^abcde$ ^bcde$ ^bce$ ^bde$ ^be$) ],
+	[ qq'(?$xism:'.'^(?:a(?:b[cd]?)?|bd?e?f)$)', qw(^a$ ^ab$ ^abc$ ^abd$ ^bdef$ ^bdf$ ^bef$ ^bf$) ],
+	[ qq'(?$xism:'.'^(?:a(?:bc?|dd)?|bd?e?f)$)', qw(^a$ ^ab$ ^abc$ ^add$ ^bdef$ ^bdf$ ^bef$ ^bf$) ],
+	[ qq'(?$xism:'.'^(?:a(?:bc?|de)?|bc?d?f)$)', qw(^a$ ^ab$ ^abc$ ^ade$ ^bcdf$ ^bcf$ ^bdf$ ^bf$) ],
+	[ qq'(?$xism:'.'^(?:a(?:bc?|de)?|cd?e?f)$)', qw(^a$ ^ab$ ^abc$ ^ade$ ^cdef$ ^cdf$ ^cef$ ^cf$) ],
+	[ qq'(?$xism:'.'^(?:a(?:bc?|e)?|bc?de?f)$)', qw(^a$ ^ab$ ^abc$ ^ae$ ^bcdef$ ^bcdf$ ^bdef$ ^bdf$) ],
+	[ qq'(?$xism:'.'^(?:a(?:bc?|e)?|b(?:cd)?e?f)$)', qw(^a$ ^ab$ ^abc$ ^ae$ ^bcdef$ ^bcdf$ ^bef$ ^bf$) ],
+	[ qq'(?$xism:'.'^(?:b(?:cde?|d?e)f|a(?:bc?|e)?)$)',
+		qw(^a$ ^ab$ ^abc$ ^ae$ ^bcdef$ ^bcdf$ ^bdef$ ^bef$) ],
+	[ qq'(?$xism:\\b(?:c[de]|ab)\\b)', qw(ab cd ce), {anchor_word => 1} ],
+	[ qq'(?$xism:\\b(?:c[de]|ab))',    qw(ab cd ce), {anchor_word_begin => 1} ],
+	[ qq'(?$xism:'.'^(?:c[de]|ab)$)',     qw(ab cd ce), {anchor_line => 1} ],
+	[ qq'(?$xism:(?:c[de]|ab))',       qw(ab cd ce), {anchor_line => 0} ],
+	[ qq'(?$xism:'.'(?:c[de]|ab)$)',      qw(ab cd ce), {anchor_line_end => 1} ],
+	[ qq'(?$xism:\\A(?:c[de]|ab)\\Z)', qw(ab cd ce), {anchor_string => 1} ],
+	[ qq'(?$xism:(?:c[de]|ab))',       qw(ab cd ce), {anchor_string => 0} ],
+	[ qq'(?$xism:x[[:punct:]][yz])',   qw(x[[:punct:]]y x[[:punct:]]z) ],
 ) {
-    my $result = shift @$test;
-    my $param = ref($test->[-1]) eq 'HASH' ? pop @$test : {};
-    my $r = Regexp::Assemble->new(%$param)->add(@$test);
-    my $args = '(' . join( ') (', @$test ) . ')';
-    if (keys %$param) {
-        $args .= ' {'
-            . join( ', ', map {"$_ => $param->{$_}"} sort keys %$param)
-            . '}';
-    }
-    is( $r->re, $result, "add $args")
+	my $result = shift @$test;
+	my $param = ref($test->[-1]) eq 'HASH' ? pop @$test : {};
+	my $r = Regexp::Assemble->new(%$param)->add(@$test);
+	my $args = '(' . join( ') (', @$test ) . ')';
+	if (keys %$param) {
+		$args .= ' {'
+			. join( ', ', map {"$_ => $param->{$_}"} sort keys %$param)
+			. '}';
+	}
+	is( $r->re, $result, "add $args")
 }
 
 {
-    my $r = Regexp::Assemble->new->add( 'de' );
-    my $re = $r->re;
-    is( "$re", qq'(?$xism:de)', 'de' );
-    my $re2 = $r->re;
-    is( "$re2", qq'(?$xism:de)', 'de again' );
+	my $r = Regexp::Assemble->new->add( 'de' );
+	my $re = $r->re;
+	is( "$re", qq'(?$xism:de)', 'de' );
+	my $re2 = $r->re;
+	is( "$re2", qq'(?$xism:de)', 'de again' );
 }
 
 is( Regexp::Assemble->new->lookahead->add( qw/
-    car cart card carp carion
-    / )->as_string,
-    'car(?:(?=[dipt])(?:[dpt]|ion))?', 'lookahead car carp cart card carion' );
+	car cart card carp carion
+	/ )->as_string,
+	'car(?:(?=[dipt])(?:[dpt]|ion))?', 'lookahead car carp cart card carion' );
 
 is( Regexp::Assemble->new->anchor_word
-    ->add(qw(ab cd ce))
-    ->as_string, '\\b(?:c[de]|ab)\\b', 'implicit anchor word via method' );
+	->add(qw(ab cd ce))
+	->as_string, '\\b(?:c[de]|ab)\\b', 'implicit anchor word via method' );
 
 is( Regexp::Assemble->new->anchor_word_end
-    ->add(qw(ab cd ce))
-    ->as_string, '(?:c[de]|ab)\\b', 'implicit anchor word end via method' );
+	->add(qw(ab cd ce))
+	->as_string, '(?:c[de]|ab)\\b', 'implicit anchor word end via method' );
 
 is( Regexp::Assemble->new->anchor_word(0)
-    ->add(qw(ab cd ce))
-    ->as_string, '(?:c[de]|ab)', 'no implicit anchor word' );
+	->add(qw(ab cd ce))
+	->as_string, '(?:c[de]|ab)', 'no implicit anchor word' );
 
 is( Regexp::Assemble->new( anchor_word => 1 )->anchor_word_end(0)
-    ->add(qw(ab cd ce))
-    ->as_string, '\\b(?:c[de]|ab)', 'implicit anchor word, no anchor word end' );
+	->add(qw(ab cd ce))
+	->as_string, '\\b(?:c[de]|ab)', 'implicit anchor word, no anchor word end' );
 
 is( Regexp::Assemble->new->anchor_word_begin(1)
-    ->add(qw(ab cd ce))
-    ->as_string, '\\b(?:c[de]|ab)', 'implicit anchor word begin' );
+	->add(qw(ab cd ce))
+	->as_string, '\\b(?:c[de]|ab)', 'implicit anchor word begin' );
 
 is( Regexp::Assemble->new
-    ->add(qw(ab cd ce))
-    ->anchor_line
-    ->as_string, '^(?:c[de]|ab)$', 'implicit anchor line via new' );
+	->add(qw(ab cd ce))
+	->anchor_line
+	->as_string, '^(?:c[de]|ab)$', 'implicit anchor line via new' );
 
 is( Regexp::Assemble->new
-    ->add(qw(ab cd ce))
-    ->anchor_line_begin
-    ->as_string, '^(?:c[de]|ab)', 'implicit anchor line via method' );
+	->add(qw(ab cd ce))
+	->anchor_line_begin
+	->as_string, '^(?:c[de]|ab)', 'implicit anchor line via method' );
 
 is( Regexp::Assemble->new->anchor_line_begin->anchor_line(0)
-    ->add(qw(ab cd ce))
-    ->as_string, '(?:c[de]|ab)', 'no implicit anchor line via method' );
+	->add(qw(ab cd ce))
+	->as_string, '(?:c[de]|ab)', 'no implicit anchor line via method' );
 
 is( Regexp::Assemble->new
-    ->add(qw(ab cd ce))
-    ->anchor_string
-    ->as_string, '\\A(?:c[de]|ab)\\Z', 'implicit anchor string via method' );
+	->add(qw(ab cd ce))
+	->anchor_string
+	->as_string, '\\A(?:c[de]|ab)\\Z', 'implicit anchor string via method' );
 
 is( Regexp::Assemble->new
-    ->add(qw(ab cd ce))
-    ->anchor_string_absolute
-    ->as_string, '\\A(?:c[de]|ab)\\z', 'implicit anchor string absolute via method' );
+	->add(qw(ab cd ce))
+	->anchor_string_absolute
+	->as_string, '\\A(?:c[de]|ab)\\z', 'implicit anchor string absolute via method' );
 
 is( Regexp::Assemble->new(anchor_string_absolute => 1)
-    ->add(qw(de df fe))
-    ->as_string, '\\A(?:d[ef]|fe)\\z', 'implicit anchor string absolute via new' );
+	->add(qw(de df fe))
+	->as_string, '\\A(?:d[ef]|fe)\\z', 'implicit anchor string absolute via new' );
 
 is( Regexp::Assemble->new(anchor_string_absolute => 1, anchor_string_begin => 0)
-    ->add(qw(de df))
-    ->as_string, 'd[ef]\\z', 'anchor string absolute and no anchor_string_begin via new' );
+	->add(qw(de df))
+	->as_string, 'd[ef]\\z', 'anchor string absolute and no anchor_string_begin via new' );
 
 is( Regexp::Assemble->new(anchor_word => 1, anchor_word_end => 0)
-    ->add(qw(ze zf zg))
-    ->as_string, '\bz[efg]', 'anchor word and no anchor_word_begin via new' );
+	->add(qw(ze zf zg))
+	->as_string, '\bz[efg]', 'anchor word and no anchor_word_begin via new' );
 
 is( Regexp::Assemble->new(anchor_string_absolute => 0)
-    ->add(qw(de df fe))
-    ->as_string, '(?:d[ef]|fe)', 'no implicit anchor string absolute via new' );
+	->add(qw(de df fe))
+	->as_string, '(?:d[ef]|fe)', 'no implicit anchor string absolute via new' );
 
 is( Regexp::Assemble->new
-    ->add(qw(ab cd ce))
-    ->anchor_word_begin
-    ->anchor_string_end_absolute
-    ->as_string, '\\b(?:c[de]|ab)\\z',
-        'implicit anchor word begin/string absolute end via method'
+	->add(qw(ab cd ce))
+	->anchor_word_begin
+	->anchor_string_end_absolute
+	->as_string, '\\b(?:c[de]|ab)\\z',
+		'implicit anchor word begin/string absolute end via method'
 );
 
 is( Regexp::Assemble->new
-    ->add(qw(ab ad))
-    ->anchor_string(1)
-    ->anchor_string_end(0)
-    ->as_string, '\\Aa[bd]',
-        'explicit anchor string/no end via method'
+	->add(qw(ab ad))
+	->anchor_string(1)
+	->anchor_string_end(0)
+	->as_string, '\\Aa[bd]',
+		'explicit anchor string/no end via method'
 );
 
 is( Regexp::Assemble->new
-    ->anchor_string_end
-    ->add(qw(ab ad))
-    ->as_string, 'a[bd]\\Z',
-        'anchor string end via method'
+	->anchor_string_end
+	->add(qw(ab ad))
+	->as_string, 'a[bd]\\Z',
+		'anchor string end via method'
 );
 
 is( Regexp::Assemble->new
-    ->anchor_string_absolute(1)
-    ->add(qw(ab ad))
-    ->as_string, '\\Aa[bd]\\z',
-        'anchor string end via method'
+	->anchor_string_absolute(1)
+	->add(qw(ab ad))
+	->as_string, '\\Aa[bd]\\z',
+		'anchor string end via method'
 );
 
 is( Regexp::Assemble->new(anchor_word_begin => 1, anchor_string_end_absolute => 1)
-    ->add(qw(de ad be ef))
-    ->as_string, '\\b(?:[bd]e|ad|ef)\\z',
-        'implicit anchor word begin/string absolute end via new'
+	->add(qw(de ad be ef))
+	->as_string, '\\b(?:[bd]e|ad|ef)\\z',
+		'implicit anchor word begin/string absolute end via new'
 );
 
 is( Regexp::Assemble->new
-    ->add(qw(ab cd ce))
-    ->anchor_word_begin
-    ->anchor_string_begin
-    ->as_string, '\\b(?:c[de]|ab)',
-        'implicit anchor word beats string'
+	->add(qw(ab cd ce))
+	->anchor_word_begin
+	->anchor_string_begin
+	->as_string, '\\b(?:c[de]|ab)',
+		'implicit anchor word beats string'
 );
 
 TODO: {
-    use vars '$TODO';
-    local $TODO = "\\d+ does not absorb digits";
+	use vars '$TODO';
+	local $TODO = "\\d+ does not absorb digits";
 
-    is( Regexp::Assemble->new->add( '5', '\\d+' )->as_string,
-        '\\d+', '\\d+ absorbs single char',
-    );
+	is( Regexp::Assemble->new->add( '5', '\\d+' )->as_string,
+		'\\d+', '\\d+ absorbs single char',
+	);
 
-    is( Regexp::Assemble->new->add( '54321', '\\d+' )->as_string,
-        '\\d+', '\\d+ absorbs multiple chars',
-    );
+	is( Regexp::Assemble->new->add( '54321', '\\d+' )->as_string,
+		'\\d+', '\\d+ absorbs multiple chars',
+	);
 
-    is( Regexp::Assemble->new
-        ->add( qw/ abz acdez a5txz a7z /, 'a\\d+z', 'a\\d+-\\d+z' ) # 5.6.0 kluge
-        ->as_string, 'a(?:b|(?:\d+-)?\d+|5tx|cde)z',
-        'abz a\\d+z acdez a\\d+-\\d+z a5txz a7z'
-    );
+	is( Regexp::Assemble->new
+		->add( qw/ abz acdez a5txz a7z /, 'a\\d+z', 'a\\d+-\\d+z' ) # 5.6.0 kluge
+		->as_string, 'a(?:b|(?:\d+-)?\d+|5tx|cde)z',
+		'abz a\\d+z acdez a\\d+-\\d+z a5txz a7z'
+	);
 }
 
 my $mute = Regexp::Assemble->new->mutable(1);
@@ -367,12 +367,12 @@ $red->add( 'dig' );
 is( $red->as_string, 'dig', 'mute dig 2' );
 
 is( Regexp::Assemble->new->add(qw(ab cd))->as_string(indent => 0),
-    '(?:ab|cd)', 'indent 0'
+	'(?:ab|cd)', 'indent 0'
 );
 
 is( Regexp::Assemble->new
-    ->add( qw/ dldrt dndrt dldt dndt dx / )
-    ->as_string(indent => 3),
+	->add( qw/ dldrt dndrt dldt dndt dx / )
+	->as_string(indent => 3),
 'd
 (?:
    [ln]dr?t
@@ -381,8 +381,8 @@ is( Regexp::Assemble->new
 ,  'dldrt dndrt dldt dndt dx (indent 3)' );
 
 is( Regexp::Assemble->new( indent => 2 )
-    ->add( qw/foo bar/ )
-    ->as_string,
+	->add( qw/foo bar/ )
+	->as_string,
 '(?:
   bar
   |foo
@@ -390,9 +390,9 @@ is( Regexp::Assemble->new( indent => 2 )
 , 'pretty foo bar' );
 
 is( Regexp::Assemble->new
-    ->indent(2)
-    ->add( qw/food fool bar/ )
-    ->as_string,
+	->indent(2)
+	->add( qw/food fool bar/ )
+	->as_string,
 '(?:
   foo[dl]
   |bar
@@ -400,9 +400,9 @@ is( Regexp::Assemble->new
 , 'pretty food fool bar' );
 
 is( Regexp::Assemble->new
-    ->add( qw/afood afool abar/ )
-    ->indent(2)
-    ->as_string,
+	->add( qw/afood afool abar/ )
+	->indent(2)
+	->as_string,
 'a
 (?:
   foo[dl]
@@ -411,31 +411,31 @@ is( Regexp::Assemble->new
 , 'pretty afood afool abar' );
 
 is( Regexp::Assemble->new
-    ->add( qw/dab dam day/ )
-    ->as_string(indent => 2),
+	->add( qw/dab dam day/ )
+	->as_string(indent => 2),
 'da[bmy]', 'pretty dab dam day' );
 
 is( Regexp::Assemble->new(indent => 5)
-    ->add( qw/be bed/ )
-    ->as_string(indent => 2),
+	->add( qw/be bed/ )
+	->as_string(indent => 2),
 'bed?'
 , 'pretty be bed' );
 
 is( Regexp::Assemble->new(indent => 5)
-    ->add( qw/b-d b\.d/ )
-    ->as_string(indent => 2),
+	->add( qw/b-d b\.d/ )
+	->as_string(indent => 2),
 'b[-.]d'
 , 'pretty b-d b\.d' );
 
 is( Regexp::Assemble->new
-    ->add( qw/be bed beg bet / )
-    ->as_string(indent => 2),
+	->add( qw/be bed beg bet / )
+	->as_string(indent => 2),
 'be[dgt]?'
 , 'pretty be bed beg bet' );
 
 is( Regexp::Assemble->new
-    ->add( qw/afoodle afoole abarle/ )
-    ->as_string(indent => 2),
+	->add( qw/afoodle afoole abarle/ )
+	->as_string(indent => 2),
 'a
 (?:
   food?
@@ -445,8 +445,8 @@ le'
 , 'pretty afoodle afoole abarle' );
 
 is( Regexp::Assemble->new
-    ->add( qw/afar afoul abate aback/ )
-    ->as_string(indent => 2),
+	->add( qw/afar afoul abate aback/ )
+	->as_string(indent => 2),
 'a
 (?:
   ba
@@ -464,8 +464,8 @@ is( Regexp::Assemble->new
 
 
 is( Regexp::Assemble->new
-    ->add( qw/stormboy steamboy saltboy sockboy/ )
-    ->as_string(indent => 5),
+	->add( qw/stormboy steamboy saltboy sockboy/ )
+	->as_string(indent => 5),
 's
 (?:
      t
@@ -481,8 +481,8 @@ boy'
 , 'pretty stormboy steamboy saltboy sockboy' );
 
 is( Regexp::Assemble->new
-    ->add( qw/stormboy steamboy stormyboy steamyboy saltboy sockboy/ )
-    ->as_string(indent => 4),
+	->add( qw/stormboy steamboy stormyboy steamyboy saltboy sockboy/ )
+	->as_string(indent => 4),
 's
 (?:
     t
@@ -498,8 +498,8 @@ boy'
 , 'pretty stormboy steamboy stormyboy steamyboy saltboy sockboy' );
 
 is( Regexp::Assemble->new
-    ->add( qw/stormboy steamboy stormyboy steamyboy stormierboy steamierboy saltboy/ )
-    ->as_string(indent => 1),
+	->add( qw/stormboy steamboy stormyboy steamyboy stormierboy steamierboy saltboy/ )
+	->as_string(indent => 1),
 's
 (?:
  t
@@ -519,8 +519,8 @@ boy'
 , 'pretty stormboy steamboy stormyboy steamyboy stormierboy steamierboy saltboy' );
 
 is( Regexp::Assemble->new
-    ->add( qw/showerless showeriness showless showiness show shows/ )
-    ->as_string(indent => 4),
+	->add( qw/showerless showeriness showless showiness show shows/ )
+	->as_string(indent => 4),
 'show
 (?:
     (?:
@@ -539,8 +539,8 @@ is( Regexp::Assemble->new
 ?' , 'pretty showerless showeriness showless showiness show shows' );
 
 is( Regexp::Assemble->new->add( qw/
-    showerless showeriness showdeless showdeiness showless showiness show shows
-    / )->as_string(indent => 4),
+	showerless showeriness showdeless showdeiness showless showiness show shows
+	/ )->as_string(indent => 4),
 'show
 (?:
     (?:
@@ -560,8 +560,8 @@ is( Regexp::Assemble->new->add( qw/
 ?' , 'pretty showerless showeriness showdeless showdeiness showless showiness show shows' );
 
 is( Regexp::Assemble->new->add( qw/
-        convenient consort concert
-    / )->as_string(indent => 4),
+		convenient consort concert
+	/ )->as_string(indent => 4),
 'con
 (?:
     (?:
@@ -574,8 +574,8 @@ is( Regexp::Assemble->new->add( qw/
 t', 'pretty convenient consort concert' );
 
 is( Regexp::Assemble->new->add( qw/
-        200.1 202.1 207.4 208.3 213.2
-    / )->as_string(indent => 4),
+		200.1 202.1 207.4 208.3 213.2
+	/ )->as_string(indent => 4),
 '2
 (?:
     0
@@ -589,8 +589,8 @@ is( Regexp::Assemble->new->add( qw/
 
 
 is( Regexp::Assemble->new->add( qw/
-        yammail\.com yanmail\.com yeah\.net yourhghorder\.com yourload\.com
-    / )->as_string(indent => 4),
+		yammail\.com yanmail\.com yeah\.net yourhghorder\.com yourload\.com
+	/ )->as_string(indent => 4),
 'y
 (?:
     (?:
@@ -607,8 +607,8 @@ is( Regexp::Assemble->new->add( qw/
 , 'pretty yammail.com yanmail.com yeah.net yourhghorder.com yourload.com' );
 
 is( Regexp::Assemble->new->add( qw/
-        convenient containment consort concert
-    / )->as_string(indent => 4),
+		convenient containment consort concert
+	/ )->as_string(indent => 4),
 'con
 (?:
     (?:
@@ -627,8 +627,8 @@ t'
 , 'pretty convenient containment consort concert' );
 
 is( Regexp::Assemble->new->add( qw/
-        sat sit bat bit sad sid bad bid
-    / )->as_string(indent => 5),
+		sat sit bat bit sad sid bad bid
+	/ )->as_string(indent => 5),
 '(?:
      b
      (?:
@@ -644,9 +644,9 @@ is( Regexp::Assemble->new->add( qw/
 , 'pretty sat sit bat bit sad sid bad bid' );
 
 is( Regexp::Assemble->new->add( qw/
-        commercial\.net compuserve\.com compuserve\.net concentric\.net
-        coolmail\.com coventry\.com cox\.net
-    / )->as_string(indent => 5),
+		commercial\.net compuserve\.com compuserve\.net concentric\.net
+		coolmail\.com coventry\.com cox\.net
+	/ )->as_string(indent => 5),
 'co
 (?:
      m
@@ -674,10 +674,10 @@ is( Regexp::Assemble->new->add( qw/
 , 'pretty c*.*' );
 
 is( Regexp::Assemble->new->add( qw/
-        ambient\.at agilent\.com americanexpress\.com amnestymail\.com
-        amuromail\.com angelfire\.com anya\.com anyi\.com aol\.com
-        aolmail\.com artfiles\.de arcada\.fi att\.net
-    / )->as_string(indent => 5),
+		ambient\.at agilent\.com americanexpress\.com amnestymail\.com
+		amuromail\.com angelfire\.com anya\.com anyi\.com aol\.com
+		aolmail\.com artfiles\.de arcada\.fi att\.net
+	/ )->as_string(indent => 5),
 'a
 (?:
      m
@@ -717,8 +717,8 @@ is( Regexp::Assemble->new->add( qw/
 )' , 'pretty a*.*' );
 
 is( Regexp::Assemble->new->add( qw/
-    looked choked hooked stoked toked baked faked
-    / )->as_string(indent => 4),
+	looked choked hooked stoked toked baked faked
+	/ )->as_string(indent => 4),
 '(?:
     (?:
         [hl]o
@@ -737,7 +737,7 @@ liaison mason meson midseason nonperson outreason parson person poison postseaso
 precomparison preseason prison reason recomparison reimprison salesperson samson
 season stepgrandson stepson stonemason tradesperson treason unison venison vison
 whoreson
-    / )->as_string(indent => 4),
+	/ )->as_string(indent => 4),
 '(?:
     p
     (?:
@@ -858,10 +858,10 @@ whoreson
 son' , '.*son' );
 
 is( Regexp::Assemble->new->add( qw/
-    deathweed deerweed deeded detached debauched deboshed detailed
-    defiled deviled defined declined determined declared deminatured
-    debentured deceased decomposed demersed depressed dejected
-    deflected delighted
+	deathweed deerweed deeded detached debauched deboshed detailed
+	defiled deviled defined declined determined declared deminatured
+	debentured deceased decomposed demersed depressed dejected
+	deflected delighted
 / )->as_string(indent => 2),
 'de
 (?:

--- a/t/04_match.t
+++ b/t/04_match.t
@@ -7,12 +7,12 @@
 
 use strict;
 eval qq{
-    use Test::More tests => 1381;
+	use Test::More tests => 1381;
 };
 if( $@ ) {
-    warn "# Test::More not available, no tests performed\n";
-    print "1..1\nok 1\n";
-    exit 0;
+	warn "# Test::More not available, no tests performed\n";
+	print "1..1\nok 1\n";
+	exit 0;
 }
 
 use Regexp::Assemble;
@@ -30,109 +30,109 @@ my $win32_56x = ($^O eq 'MSWin32' && $] < 5.008) ? 1 : 0;
 diag("enabling defensive workaround for $] on $^O") if $win32_56x;
 
 {
-    for my $outer ( 0 .. 15 ) {
-        my $re = Regexp::Assemble->new->anchor_string->chomp(0);
-        for my $inner ( 0 .. 15 ) {
-            next if $win32_56x and $subchr == ($outer*16 + $inner);
-            $re->add( quotemeta( chr( $outer*16 + $inner )));
-        }
-        for my $inner ( 0 .. 15 ) {
-            if( $win32_56x and $subchr == ($outer*16 + $inner)) {
-                 ok( 1, "faking $subchr for 5.6 on Win32" );
-            }
-            else {
-                my $ch = chr($outer*16 + $inner);
-                like( $ch, qr/$re/, "run $ch ($outer:$inner) $re" );
-            }
-        }
-    }
+	for my $outer ( 0 .. 15 ) {
+		my $re = Regexp::Assemble->new->anchor_string->chomp(0);
+		for my $inner ( 0 .. 15 ) {
+			next if $win32_56x and $subchr == ($outer*16 + $inner);
+			$re->add( quotemeta( chr( $outer*16 + $inner )));
+		}
+		for my $inner ( 0 .. 15 ) {
+			if( $win32_56x and $subchr == ($outer*16 + $inner)) {
+				 ok( 1, "faking $subchr for 5.6 on Win32" );
+			}
+			else {
+				my $ch = chr($outer*16 + $inner);
+				like( $ch, qr/$re/, "run $ch ($outer:$inner) $re" );
+			}
+		}
+	}
 }
 
 for( 0 .. 255 ) {
-    if( $win32_56x and $subchr == $_) {
-        pass("Fake a single for 5.6 on Win32");
-        next;
-    }
-    my $ch = chr($_);
-    my $qm = Regexp::Assemble->new(chomp=>0)->anchor_string->add(quotemeta($ch));
-    like( $ch, qr/$qm/, "quotemeta(chr($_))" );
+	if( $win32_56x and $subchr == $_) {
+		pass("Fake a single for 5.6 on Win32");
+		next;
+	}
+	my $ch = chr($_);
+	my $qm = Regexp::Assemble->new(chomp=>0)->anchor_string->add(quotemeta($ch));
+	like( $ch, qr/$qm/, "quotemeta(chr($_))" );
 }
 
 for( 0 .. 127 ) {
-    if( $win32_56x and $subchr == $_) {
-        pass( "Fake a hi for 5.6 on Win32");
-        pass( "Fake a lo for 5.6 on Win32");
-        next;
-    }
-    my $lo = chr($_);
-    my $hi = chr($_+128);
-    my $qm = Regexp::Assemble->new(chomp => 0, anchor_string => 1)->add(
-        quotemeta($lo),
-        quotemeta($hi),
-    );
-    like( $lo, qr/$qm/, "$_: quotemeta($lo) lo" );
-    like( $hi, qr/$qm/, "$_: quotemeta($hi) hi" );
+	if( $win32_56x and $subchr == $_) {
+		pass( "Fake a hi for 5.6 on Win32");
+		pass( "Fake a lo for 5.6 on Win32");
+		next;
+	}
+	my $lo = chr($_);
+	my $hi = chr($_+128);
+	my $qm = Regexp::Assemble->new(chomp => 0, anchor_string => 1)->add(
+		quotemeta($lo),
+		quotemeta($hi),
+	);
+	like( $lo, qr/$qm/, "$_: quotemeta($lo) lo" );
+	like( $hi, qr/$qm/, "$_: quotemeta($hi) hi" );
 }
 
 sub match {
-    my $re   = Regexp::Assemble->new;
-    my $rela = Regexp::Assemble->new->lookahead(1);
-    my $tag = shift;
-    $re->add(@_);
-    $rela->add(@_);
-    my $reind = $re->clone;
-    $reind = $re->clone->flags('x')->re(indent => 3);
-    my $rered = $re->clone->reduce(0);
-    my $str;
-    for $str (@_) {
-        like( $str, qr/^$re$/,     "-- $tag: $str" ) or diag( " fail $str\n# match by $re\n" );
-        like( $str, qr/^$rela$/,   "LA $tag: $str" ) or diag( " fail $str\n# match by lookahead $rela\n" );
-        like( $str, qr/^$reind$/x, "IN $tag: $str" ) or diag( " fail $str\n# match by indented $reind\n" );
-        like( $str, qr/^$rered$/,  "RD $tag: $str" ) or diag( " fail $str\n# match by non-reduced $rered\n" );
-    }
+	my $re   = Regexp::Assemble->new;
+	my $rela = Regexp::Assemble->new->lookahead(1);
+	my $tag = shift;
+	$re->add(@_);
+	$rela->add(@_);
+	my $reind = $re->clone;
+	$reind = $re->clone->flags('x')->re(indent => 3);
+	my $rered = $re->clone->reduce(0);
+	my $str;
+	for $str (@_) {
+		like( $str, qr/^$re$/,     "-- $tag: $str" ) or diag( " fail $str\n# match by $re\n" );
+		like( $str, qr/^$rela$/,   "LA $tag: $str" ) or diag( " fail $str\n# match by lookahead $rela\n" );
+		like( $str, qr/^$reind$/x, "IN $tag: $str" ) or diag( " fail $str\n# match by indented $reind\n" );
+		like( $str, qr/^$rered$/,  "RD $tag: $str" ) or diag( " fail $str\n# match by non-reduced $rered\n" );
+	}
 }
 
 sub match_list {
-    my $tag  = shift;
-    my $patt = shift;
-    my $test = shift;
-    my $re   = Regexp::Assemble->new->add(@$patt);
-    my $rela = Regexp::Assemble->new->lookahead(1)->add(@$patt);
-    my $str;
-    for $str (@$test) {
-        ok( $str =~ /^$re$/, "re $tag: $str" ) or diag( "fail re $str\n# in $re\n" );
-        ok( $str =~ /^$rela$/, "rela $tag: $str" ) or diag( "fail rela $str\n# in $rela\n" );
-    }
+	my $tag  = shift;
+	my $patt = shift;
+	my $test = shift;
+	my $re   = Regexp::Assemble->new->add(@$patt);
+	my $rela = Regexp::Assemble->new->lookahead(1)->add(@$patt);
+	my $str;
+	for $str (@$test) {
+		ok( $str =~ /^$re$/, "re $tag: $str" ) or diag( "fail re $str\n# in $re\n" );
+		ok( $str =~ /^$rela$/, "rela $tag: $str" ) or diag( "fail rela $str\n# in $rela\n" );
+	}
 }
 
 {
-    my $re = Regexp::Assemble->new( flags => 'i' )
-        ->add( '^fg' )
-        ->re;
-    like( 'fgx', qr/$re/, 'fgx/i' );
-    like( 'Fgx', qr/$re/, 'Fgx/i' );
-    like( 'FGx', qr/$re/, 'FGx/i' );
-    like( 'fGx', qr/$re/, 'fGx/i' );
-    unlike( 'F', qr/$re/, 'F/i' );
+	my $re = Regexp::Assemble->new( flags => 'i' )
+		->add( '^fg' )
+		->re;
+	like( 'fgx', qr/$re/, 'fgx/i' );
+	like( 'Fgx', qr/$re/, 'Fgx/i' );
+	like( 'FGx', qr/$re/, 'FGx/i' );
+	like( 'fGx', qr/$re/, 'fGx/i' );
+	unlike( 'F', qr/$re/, 'F/i' );
 }
 
 {
-    my $re = Regexp::Assemble->new( flags => 'x' )
-        ->add( '^fish' )
-        ->add( '^flash' )
-        ->add( '^fetish' )
-        ->add( '^foolish' )
-        ->re( indent => 2 );
-    like( 'fish', qr/$re/, 'fish/x' );
-    like( 'flash', qr/$re/, 'flash/x' );
-    like( 'fetish', qr/$re/, 'fetish/x' );
-    like( 'foolish', qr/$re/, 'foolish/x' );
-    unlike( 'fetch', qr/$re/, 'fetch/x' );
+	my $re = Regexp::Assemble->new( flags => 'x' )
+		->add( '^fish' )
+		->add( '^flash' )
+		->add( '^fetish' )
+		->add( '^foolish' )
+		->re( indent => 2 );
+	like( 'fish', qr/$re/, 'fish/x' );
+	like( 'flash', qr/$re/, 'flash/x' );
+	like( 'fetish', qr/$re/, 'fetish/x' );
+	like( 'foolish', qr/$re/, 'foolish/x' );
+	unlike( 'fetch', qr/$re/, 'fetch/x' );
 }
 
 match_list( 'lookahead car.*',
-    [qw[caret caress careful careless caring carion carry carried]],
-    [qw[caret caress careful careless caring carion carry carried]],
+	[qw[caret caress careful careless caring carion carry carried]],
+	[qw[caret caress careful careless caring carion carry carried]],
 );
 
 match_list( 'a.x', [qw[ abx adx a.x ]] , [qw[ aax abx acx azx a4x a%x a+x a?x ]] );
@@ -144,8 +144,8 @@ match_list( 'c.z', [qw[ c^z c-z c5z cmz ]] , [qw[ c^z c-z c5z cmz ]] );
 match_list( '\d, \D', [ 'b\\d', 'b\\D' ] , [qw[ b4 bX b% b. b? ]] );
 
 match_list( 'abcd',
-    [qw[ abc abcd ac acd b bc bcd bd]],
-    [qw[ abc abcd ac acd b bc bcd bd]],
+	[qw[ abc abcd ac acd b bc bcd bd]],
+	[qw[ abc abcd ac acd b bc bcd bd]],
 );
 
 match( 'foo', qw[ foo bar rat quux ]);
@@ -171,21 +171,21 @@ match( 'd*', qw[ den-at dot-at den-pt dot-pt d-at d-pt dx ]);
 match( 'un*ed', qw[ unimped unimpeded unimpelled ]);
 
 match( '(un)?*(ing)?ing', qw[
-    sing swing sting sling
-    singing swinging stinging slinging
-    unsing unswing unsting unsling
-    unsinging unswinging unstinging unslinging
+	sing swing sting sling
+	singing swinging stinging slinging
+	unsing unswing unsting unsling
+	unsinging unswinging unstinging unslinging
 ]);
 
 match( 's.*at 1', qw[ sat sweat sailbat ]);
 
 match( 'm[eant]+', qw[ ma mae man mana manatee mane manent manna mannan mant
-    manta mat mate matta matte me mean meant meat meet meeten men met meta
-    metate mete ]);
+	manta mat mate matta matte me mean meant meat meet meeten men met meta
+	metate mete ]);
 
 match( 'ti[aeinost]+', qw[ tiao tie tien tin tine tinea tinean tineine
-    tininess tinnet tinniness tinosa tinstone tint tinta tintie tintiness
-    tintist tisane tit titanate titania titanite titano tite titi titian
-    titien tittie ]);
+	tininess tinnet tinniness tinosa tinstone tint tinta tintie tintiness
+	tintist tisane tit titanate titania titanite titano tite titi titian
+	titien tittie ]);
 
 is( $_, $fixed, '$_ has not been altered' );

--- a/t/05_hostmatch.t
+++ b/t/05_hostmatch.t
@@ -12,9 +12,9 @@ use constant file_testcount => 3; # tests requiring Test::File::Contents
 
 eval qq{use Test::More tests => 22 + file_testcount};
 if( $@ ) {
-    warn "# Test::More not available, no tests performed\n";
-    print "1..1\nok 1\n";
-    exit 0;
+	warn "# Test::More not available, no tests performed\n";
+	print "1..1\nok 1\n";
+	exit 0;
 }
 
 use constant NR_GOOD  => 45;
@@ -25,8 +25,8 @@ my $fixed = 'The scalar remains the same';
 $_ = $fixed;
 
 my $have_Test_File_Contents = do {
-    eval { require Test::File::Contents; import Test::File::Contents };
-    $@ ? 0 : 1;
+	eval { require Test::File::Contents; import Test::File::Contents };
+	$@ ? 0 : 1;
 };
 
 my @re = <DATA>;
@@ -48,46 +48,46 @@ ok( open(ERROR, '>t/error.out'), "can open t/error.out for output" ) or print "#
 
 my( $good, $bad, $error ) = (0, 0, 0);
 END {
-    if( !$error ) {
-        unlink $_ for qw{ t/good.out t/bad.out t/error.out };
-    }
+	if( !$error ) {
+		unlink $_ for qw{ t/good.out t/bad.out t/error.out };
+	}
 }
 
 ok( open(IN, 'examples/hostmatch/source.in'), "can open examples/hostmatch/source.in" ) or print "# $!\n";
 while( defined( my $rec = <IN> )) {
-    chomp $rec;
-    if( $rec =~ /^$ra$/ ) {
-        my $seen = 0;
-        my $re;
-        for $re (@re) {
-            if( $rec =~ /^$re$/ ) {
-                print BAD "$rec\n";
-                ++$bad;
-                ++$seen;
-                last;
-            }
-        }
-        if( not $seen ) {
-            print ERROR "$rec\n";
-            ++$error;
-        }
-    }
-    else {
-        my $seen = 0;
-        my $re;
-        for $re (@re) {
-            if( $rec =~ /^$re$/ ) {
-                print ERROR "$rec\n";
-                ++$error;
-                ++$seen;
-                last;
-            }
-        }
-        if( not $seen ) {
-            print GOOD "$rec\n";
-            ++$good;
-        }
-    }
+	chomp $rec;
+	if( $rec =~ /^$ra$/ ) {
+		my $seen = 0;
+		my $re;
+		for $re (@re) {
+			if( $rec =~ /^$re$/ ) {
+				print BAD "$rec\n";
+				++$bad;
+				++$seen;
+				last;
+			}
+		}
+		if( not $seen ) {
+			print ERROR "$rec\n";
+			++$error;
+		}
+	}
+	else {
+		my $seen = 0;
+		my $re;
+		for $re (@re) {
+			if( $rec =~ /^$re$/ ) {
+				print ERROR "$rec\n";
+				++$error;
+				++$seen;
+				last;
+			}
+		}
+		if( not $seen ) {
+			print GOOD "$rec\n";
+			++$good;
+		}
+	}
 }
 
 close GOOD;
@@ -100,100 +100,100 @@ is( NR_ERROR, $error,  NR_ERROR. ' records in error' );
 is( NR_GOOD+NR_BAD+NR_ERROR, $., "$. total records" );
 
 SKIP: {
-    skip( 'Test::File::Contents not installed on this system', file_testcount )
-        unless $have_Test_File_Contents;
-    my $file;
-    for $file( qw/good bad error/ ) {
-        file_contents_identical( "t/$file.out", "examples/hostmatch/$file.canonical", "saw expected $file output" );
-    }
+	skip( 'Test::File::Contents not installed on this system', file_testcount )
+		unless $have_Test_File_Contents;
+	my $file;
+	for $file( qw/good bad error/ ) {
+		file_contents_identical( "t/$file.out", "examples/hostmatch/$file.canonical", "saw expected $file output" );
+	}
 } # SKIP
 
 {
-    my $r = Regexp::Assemble->new;
-    $r->add_file('examples/file.1')->add_file('examples/file.2');
-    is( $r->as_string, '(?:b(?:l(?:ea|o)|[eo]a)t|s[aiou]ng)',
-        q{add_file('file.1'), add_file('file.2')},
-        'add_file() 2 calls'
-    );
+	my $r = Regexp::Assemble->new;
+	$r->add_file('examples/file.1')->add_file('examples/file.2');
+	is( $r->as_string, '(?:b(?:l(?:ea|o)|[eo]a)t|s[aiou]ng)',
+		q{add_file('file.1'), add_file('file.2')},
+		'add_file() 2 calls'
+	);
 
-    is(
-        Regexp::Assemble->new->chomp->add_file( qw[examples/file.1 examples/file.2] )
-        ->as_string,
-        '(?:b(?:l(?:ea|o)|[eo]a)t|s[aiou]ng)',
-        'add_file() multiple files'
-    );
+	is(
+		Regexp::Assemble->new->chomp->add_file( qw[examples/file.1 examples/file.2] )
+		->as_string,
+		'(?:b(?:l(?:ea|o)|[eo]a)t|s[aiou]ng)',
+		'add_file() multiple files'
+	);
 
-    is(
-        Regexp::Assemble->new->chomp->add_file({
-            file => [qw[examples/file.1 examples/file.2]]
-        })
-        ->as_string,
-        '(?:b(?:l(?:ea|o)|[eo]a)t|s[aiou]ng)',
-        'add_file() alternate interface'
-    );
+	is(
+		Regexp::Assemble->new->chomp->add_file({
+			file => [qw[examples/file.1 examples/file.2]]
+		})
+		->as_string,
+		'(?:b(?:l(?:ea|o)|[eo]a)t|s[aiou]ng)',
+		'add_file() alternate interface'
+	);
 
-    my $str = Regexp::Assemble->new
-        ->add_file({ file => ['examples/file.4'], rs => '/', })
-        ->as_string;
-    is( $str, '(?:(?:do|pi)g|c(?:at|ow)|hen)',
-        'add_file with explicit record separator'
-    );
+	my $str = Regexp::Assemble->new
+		->add_file({ file => ['examples/file.4'], rs => '/', })
+		->as_string;
+	is( $str, '(?:(?:do|pi)g|c(?:at|ow)|hen)',
+		'add_file with explicit record separator'
+	);
 
-    is( Regexp::Assemble->new( rs => '/' )
-        ->add_file({ file => ['examples/file.4'] })
-        ->as_string, $str, 'add_file hashref with record separator specified in new()'
-    );
+	is( Regexp::Assemble->new( rs => '/' )
+		->add_file({ file => ['examples/file.4'] })
+		->as_string, $str, 'add_file hashref with record separator specified in new()'
+	);
 
-    is( Regexp::Assemble->new
-        ->add_file({ file => 'examples/file.4', input_record_separator => '/', })
-        ->as_string, $str, 'add_file hashref with record separator specified in new()'
-    );
+	is( Regexp::Assemble->new
+		->add_file({ file => 'examples/file.4', input_record_separator => '/', })
+		->as_string, $str, 'add_file hashref with record separator specified in new()'
+	);
 
-    is( Regexp::Assemble->new( rs => '/' )
-        ->add_file('examples/file.4')
-        ->as_string, $str, 'add_file with record separator specified in new()'
-    );
+	is( Regexp::Assemble->new( rs => '/' )
+		->add_file('examples/file.4')
+		->as_string, $str, 'add_file with record separator specified in new()'
+	);
 
-    is(
-        Regexp::Assemble->new(
-            file => 'examples/file.4',
-            input_record_separator => '/',
-        )
-        ->as_string, $str,
-        'new() file and custom record separator'
-    );
+	is(
+		Regexp::Assemble->new(
+			file => 'examples/file.4',
+			input_record_separator => '/',
+		)
+		->as_string, $str,
+		'new() file and custom record separator'
+	);
 
-    {
-        local $/ = undef;
-        my $raw_contents = 'cat/dog/cow/pig/hen';
+	{
+		local $/ = undef;
+		my $raw_contents = 'cat/dog/cow/pig/hen';
 
-        is( Regexp::Assemble->new
-            ->add_file({file => 'examples/file.4'})
-            ->as_string, $raw_contents, 'add_file with no record separator'
-        );
+		is( Regexp::Assemble->new
+			->add_file({file => 'examples/file.4'})
+			->as_string, $raw_contents, 'add_file with no record separator'
+		);
 
-        is(
-            Regexp::Assemble->new(file => 'examples/file.4')->as_string,
-                $raw_contents,
-                'new() file and no record separator'
-        );
-    }
+		is(
+			Regexp::Assemble->new(file => 'examples/file.4')->as_string,
+				$raw_contents,
+				'new() file and no record separator'
+		);
+	}
 
-    eval { my $r = Regexp::Assemble->new( file => '/does/not/exist' ) };
-    is( substr($@,0,38), q{cannot open /does/not/exist for input:}, 'file does not exist for new()' );
+	eval { my $r = Regexp::Assemble->new( file => '/does/not/exist' ) };
+	is( substr($@,0,38), q{cannot open /does/not/exist for input:}, 'file does not exist for new()' );
 
-    SKIP: {
-        skip( 'ignore DOS line-ending tests on Win32', 1 ) if $^O =~ /^MSWin32/;
-        is(
-            Regexp::Assemble->new->chomp->add_file({
-                file => [qw[examples/file.3]],
-                rs   => "\r\n",
-            })
-            ->as_string,
-            '(?:e[ns]|i[ls])',
-            'add_file() with DOS line endings'
-        );
-    }
+	SKIP: {
+		skip( 'ignore DOS line-ending tests on Win32', 1 ) if $^O =~ /^MSWin32/;
+		is(
+			Regexp::Assemble->new->chomp->add_file({
+				file => [qw[examples/file.3]],
+				rs   => "\r\n",
+			})
+			->as_string,
+			'(?:e[ns]|i[ls])',
+			'add_file() with DOS line endings'
+		);
+	}
 }
 
 is( $_, $fixed, '$_ has not been altered' );

--- a/t/06_general.t
+++ b/t/06_general.t
@@ -10,9 +10,9 @@ use Regexp::Assemble;
 
 eval qq{use Test::More tests => 142 };
 if( $@ ) {
-    warn "# Test::More not available, no tests performed\n";
-    print "1..1\nok 1\n";
-    exit 0;
+	warn "# Test::More not available, no tests performed\n";
+	print "1..1\nok 1\n";
+	exit 0;
 }
 
 use constant NR_GOOD  => 45;
@@ -26,29 +26,29 @@ my $target;
 my $ra = Regexp::Assemble->new->add( qw/foo bar rat/ );
 
 for $target( qw/unfooled disembark vibration/ ) {
-    like( $target, qr/$ra/, "match ok $target" )
+	like( $target, qr/$ra/, "match ok $target" )
 }
 
 ok( !defined($ra->source()), 'source() undefined' );
 
 for $target( qw/unfooled disembark vibration/ ) {
-    unlike( $target, qr/^$ra/, "anchored match not ok $target" )
+	unlike( $target, qr/^$ra/, "anchored match not ok $target" )
 }
 
 $ra->reset;
 
 for $target( qw/unfooled disembark vibration/ ) {
-    unlike( $target, qr/$ra/, "fail after reset $target" )
+	unlike( $target, qr/$ra/, "fail after reset $target" )
 }
 
 $ra->add( qw/who what where why when/ );
 
 for $target( qw/unfooled disembark vibration/ ) {
-    unlike( $target, qr/$ra/, "fail ok $target" )
+	unlike( $target, qr/$ra/, "fail ok $target" )
 }
 
 for $target( qw/snowhouse somewhat nowhereness whyever nowhence/ ) {
-    like( $target, qr/$ra/, "new match ok $target" )
+	like( $target, qr/$ra/, "new match ok $target" )
 }
 
 $ra->reset->mutable(1);
@@ -97,334 +97,334 @@ unlike( '#de', qr/^$ra$/, '#de not matched by comment-filtered assembly' );
 like(   'abc', qr/^$ra$/, 'abc matched by comment-filtered assembly' );
 
 SKIP: {
-    skip( "is_deeply is broken in this version of Test::More (v$Test::More::VERSION)", 5 )
-        unless $Test::More::VERSION > 0.47;
+	skip( "is_deeply is broken in this version of Test::More (v$Test::More::VERSION)", 5 )
+		unless $Test::More::VERSION > 0.47;
 
-    {
-        my $orig = Regexp::Assemble->new;
-        my $clone = $orig->clone;
-        is_deeply( $orig, $clone, 'clone empty' );
-    }
+	{
+		my $orig = Regexp::Assemble->new;
+		my $clone = $orig->clone;
+		is_deeply( $orig, $clone, 'clone empty' );
+	}
 
-    {
-        my $orig = Regexp::Assemble->new->add( qw/ dig dug dog / );
-        my $clone = $orig->clone;
-        is_deeply( $orig, $clone, 'clone path' );
-    }
+	{
+		my $orig = Regexp::Assemble->new->add( qw/ dig dug dog / );
+		my $clone = $orig->clone;
+		is_deeply( $orig, $clone, 'clone path' );
+	}
 
-    {
-        my $orig = Regexp::Assemble->new->add( qw/ dig dug dog / );
-        my $clone = $orig->clone;
-        $orig->add( 'digger' );
-        $clone->add( 'digger' );
-        is_deeply( $orig, $clone, 'clone then add' );
-    }
+	{
+		my $orig = Regexp::Assemble->new->add( qw/ dig dug dog / );
+		my $clone = $orig->clone;
+		$orig->add( 'digger' );
+		$clone->add( 'digger' );
+		is_deeply( $orig, $clone, 'clone then add' );
+	}
 
-    {
-        my $orig = Regexp::Assemble->new
-            ->add( qw/ bird cat dog elephant fox/ );
-        my $clone = $orig->clone;
-        is_deeply( $orig, $clone, 'clone node' );
-    }
+	{
+		my $orig = Regexp::Assemble->new
+			->add( qw/ bird cat dog elephant fox/ );
+		my $clone = $orig->clone;
+		is_deeply( $orig, $clone, 'clone node' );
+	}
 
-    {
-        my $orig = Regexp::Assemble->new
-            ->add( qw/ after alter amber cheer steer / );
-        my $clone = $orig->clone;
-        is_deeply( $orig, $clone, 'clone more' );
-    }
+	{
+		my $orig = Regexp::Assemble->new
+			->add( qw/ after alter amber cheer steer / );
+		my $clone = $orig->clone;
+		is_deeply( $orig, $clone, 'clone more' );
+	}
 }
 
 SKIP: {
-    # If the Storable module is available, we will have used
-    # that above, however, we will not have tested the pure-Perl
-    # fallback routines.
-    skip( 'Pure-Perl clone() already tested', 5 )
-        unless $Regexp::Assemble::have_Storable;
+	# If the Storable module is available, we will have used
+	# that above, however, we will not have tested the pure-Perl
+	# fallback routines.
+	skip( 'Pure-Perl clone() already tested', 5 )
+		unless $Regexp::Assemble::have_Storable;
 
-    skip( "is_deeply is broken in this version of Test::More (v$Test::More::VERSION)", 5 )
-        unless $Test::More::VERSION > 0.47;
+	skip( "is_deeply is broken in this version of Test::More (v$Test::More::VERSION)", 5 )
+		unless $Test::More::VERSION > 0.47;
 
-    local $Regexp::Assemble::have_Storable = 0;
-    {
-        my $orig = Regexp::Assemble->new;
-        my $clone = $orig->clone;
-        is_deeply( $orig, $clone, 'clone empty' );
-    }
+	local $Regexp::Assemble::have_Storable = 0;
+	{
+		my $orig = Regexp::Assemble->new;
+		my $clone = $orig->clone;
+		is_deeply( $orig, $clone, 'clone empty' );
+	}
 
-    {
-        my $orig = Regexp::Assemble->new->add( qw/ dig dug dog / );
-        my $clone = $orig->clone;
-        is_deeply( $orig, $clone, 'clone path' );
-    }
+	{
+		my $orig = Regexp::Assemble->new->add( qw/ dig dug dog / );
+		my $clone = $orig->clone;
+		is_deeply( $orig, $clone, 'clone path' );
+	}
 
-    {
-        my $orig = Regexp::Assemble->new->add( qw/ dig dug dog / );
-        my $clone = $orig->clone;
-        $orig->add( 'digger' );
-        $clone->add( 'digger' );
-        is_deeply( $orig, $clone, 'clone then add' );
-    }
+	{
+		my $orig = Regexp::Assemble->new->add( qw/ dig dug dog / );
+		my $clone = $orig->clone;
+		$orig->add( 'digger' );
+		$clone->add( 'digger' );
+		is_deeply( $orig, $clone, 'clone then add' );
+	}
 
-    {
-        my $orig = Regexp::Assemble->new
-            ->add( qw/ bird cat dog elephant fox/ );
-        my $clone = $orig->clone;
-        is_deeply( $orig, $clone, 'clone node' );
-    }
+	{
+		my $orig = Regexp::Assemble->new
+			->add( qw/ bird cat dog elephant fox/ );
+		my $clone = $orig->clone;
+		is_deeply( $orig, $clone, 'clone node' );
+	}
 
-    {
-        my $orig = Regexp::Assemble->new
-            ->add( qw/ after alter amber cheer steer / );
-        my $clone = $orig->clone;
-        is_deeply( $orig, $clone, 'clone more' );
-    }
+	{
+		my $orig = Regexp::Assemble->new
+			->add( qw/ after alter amber cheer steer / );
+		my $clone = $orig->clone;
+		is_deeply( $orig, $clone, 'clone more' );
+	}
 }
 
 {
-    my $r = Regexp::Assemble->new ->add( qw/ dig dug / );
-    cmp_ok( $r->dump, 'eq', '[d {i=>[i g] u=>[u g]}]', 'dump path' );
+	my $r = Regexp::Assemble->new ->add( qw/ dig dug / );
+	cmp_ok( $r->dump, 'eq', '[d {i=>[i g] u=>[u g]}]', 'dump path' );
 }
 
 {
-    my $r = Regexp::Assemble->new ->add( 'a b' );
-    cmp_ok( $r->dump, 'eq', q<[a ' ' b]>, 'dump path with space' );
-    $r->insert( 'a', ' ', 'b', 'c', 'd' );
-    cmp_ok( $r->dump, 'eq', q([a ' ' b {* c=>[c d]}]),
-        'dump path with space 2' );
+	my $r = Regexp::Assemble->new ->add( 'a b' );
+	cmp_ok( $r->dump, 'eq', q<[a ' ' b]>, 'dump path with space' );
+	$r->insert( 'a', ' ', 'b', 'c', 'd' );
+	cmp_ok( $r->dump, 'eq', q([a ' ' b {* c=>[c d]}]),
+		'dump path with space 2' );
 }
 
 {
-    my $r = Regexp::Assemble->new ->add( qw/ dog cat / );
-    cmp_ok( $r->dump, 'eq', '[{c=>[c a t] d=>[d o g]}]', 'dump node' );
+	my $r = Regexp::Assemble->new ->add( qw/ dog cat / );
+	cmp_ok( $r->dump, 'eq', '[{c=>[c a t] d=>[d o g]}]', 'dump node' );
 }
 
 {
-    my $r = Regexp::Assemble->new->add( qw/ house home / );
-    $r->insert();
-    cmp_ok( $r->dump, 'eq', '[{* h=>[h o {m=>[m e] u=>[u s e]}]}]',
-        'add opt to path' );
+	my $r = Regexp::Assemble->new->add( qw/ house home / );
+	$r->insert();
+	cmp_ok( $r->dump, 'eq', '[{* h=>[h o {m=>[m e] u=>[u s e]}]}]',
+		'add opt to path' );
 }
 
 {
-    my $r = Regexp::Assemble->new->add( qw/ dog cat / );
-    $r->insert();
-    cmp_ok( $r->dump, 'eq', '[{* c=>[c a t] d=>[d o g]}]',
-        'add opt to node' );
+	my $r = Regexp::Assemble->new->add( qw/ dog cat / );
+	$r->insert();
+	cmp_ok( $r->dump, 'eq', '[{* c=>[c a t] d=>[d o g]}]',
+		'add opt to node' );
 }
 
 {
-    my $slide = Regexp::Assemble->new;
-    cmp_ok( $slide->add( qw/schoolkids acids acidoids/ )->as_string,
-        'eq', '(?:ac(?:ido)?|schoolk)ids', 'schoolkids acids acidoids' );
+	my $slide = Regexp::Assemble->new;
+	cmp_ok( $slide->add( qw/schoolkids acids acidoids/ )->as_string,
+		'eq', '(?:ac(?:ido)?|schoolk)ids', 'schoolkids acids acidoids' );
 
-    cmp_ok( $slide->add( qw/schoolkids acidoids/ )->as_string,
-        'eq', '(?:schoolk|acido)ids', 'schoolkids acidoids' );
+	cmp_ok( $slide->add( qw/schoolkids acidoids/ )->as_string,
+		'eq', '(?:schoolk|acido)ids', 'schoolkids acidoids' );
 
-    cmp_ok( $slide->add( qw/nonschoolkids nonacidoids/ )->as_string,
-        'eq', 'non(?:schoolk|acido)ids', 'nonschoolkids nonacidoids' );
+	cmp_ok( $slide->add( qw/nonschoolkids nonacidoids/ )->as_string,
+		'eq', 'non(?:schoolk|acido)ids', 'nonschoolkids nonacidoids' );
 }
 
 {
-    cmp_ok( Regexp::Assemble->new
-        ->add( qw( sing singing ))
-        ->as_string, 'eq', 'sing(?:ing)?', 'super slide sing singing' # no sliding done
-    );
+	cmp_ok( Regexp::Assemble->new
+		->add( qw( sing singing ))
+		->as_string, 'eq', 'sing(?:ing)?', 'super slide sing singing' # no sliding done
+	);
 
-    cmp_ok( Regexp::Assemble->new
-        ->add( qw( sing singing sling))
-        ->as_string, 'eq', 's(?:(?:ing)?|l)ing',
-        'super slide sing singing sling'
-    );
+	cmp_ok( Regexp::Assemble->new
+		->add( qw( sing singing sling))
+		->as_string, 'eq', 's(?:(?:ing)?|l)ing',
+		'super slide sing singing sling'
+	);
 
-    cmp_ok( Regexp::Assemble->new
-        ->add( qw( sing singing sling slinging))
-        ->as_string, 'eq', 'sl?(?:ing)?ing',
-        'super slide sing singing sling slinging'
-    );
+	cmp_ok( Regexp::Assemble->new
+		->add( qw( sing singing sling slinging))
+		->as_string, 'eq', 'sl?(?:ing)?ing',
+		'super slide sing singing sling slinging'
+	);
 
-    cmp_ok( Regexp::Assemble->new
-        ->add( qw( sing singing sling slinging sting stinging ))
-        ->as_string, 'eq', 's[lt]?(?:ing)?ing',
-        'super slide sing singing sling slinging sting stinging'
-    );
+	cmp_ok( Regexp::Assemble->new
+		->add( qw( sing singing sling slinging sting stinging ))
+		->as_string, 'eq', 's[lt]?(?:ing)?ing',
+		'super slide sing singing sling slinging sting stinging'
+	);
 
-    cmp_ok( Regexp::Assemble->new
-        ->add( qw( sing singing sling slinging sting stinging string stringing swing swinging ))
-        ->as_string, 'eq', 's(?:[lw]|tr?)?(?:ing)?ing',
-        'super slide sing singing sling slinging sting stinging string stringing swing swinging'
-    );
+	cmp_ok( Regexp::Assemble->new
+		->add( qw( sing singing sling slinging sting stinging string stringing swing swinging ))
+		->as_string, 'eq', 's(?:[lw]|tr?)?(?:ing)?ing',
+		'super slide sing singing sling slinging sting stinging string stringing swing swinging'
+	);
 }
 {
-    my $re = Regexp::Assemble->new( flags => 'i' )->add( qw/ ^ab ^are de / );
-    like( 'able', qr/$re/, '{^ab ^are de} /i matches able' );
-    like( 'About', qr/$re/, '{^ab ^are de} /i matches About' );
-    unlike( 'bare', qr/$re/, '{^ab ^are de} /i fails bare' );
-    like( 'death', qr/$re/, '{^ab ^are de} /i matches death' );
-    like( 'DEEP', qr/$re/, '{^ab ^are de} /i matches DEEP' );
-}
-
-{
-    my $re = Regexp::Assemble->new->add( qw/abc def ghi/ );
-    cmp_ok( $re->{stats_add},    '==', 3, "stats add 3x3" );
-    cmp_ok( $re->{stats_raw},    '==', 9, "stats raw 3x3" );
-    cmp_ok( $re->{stats_cooked}, '==', 9, "stats cooked 3x3" );
-    ok( !defined($re->{stats_dup}), "stats dup 3x3" );
-
-    $re->add( 'de' );
-    cmp_ok( $re->{stats_add},    '==',  4, "stats add 3x3 +1" );
-    cmp_ok( $re->{stats_raw},    '==', 11, "stats raw 3x3 +1" );
-    cmp_ok( $re->{stats_cooked}, '==', 11, "stats cooked 3x3 +1" );
+	my $re = Regexp::Assemble->new( flags => 'i' )->add( qw/ ^ab ^are de / );
+	like( 'able', qr/$re/, '{^ab ^are de} /i matches able' );
+	like( 'About', qr/$re/, '{^ab ^are de} /i matches About' );
+	unlike( 'bare', qr/$re/, '{^ab ^are de} /i fails bare' );
+	like( 'death', qr/$re/, '{^ab ^are de} /i matches death' );
+	like( 'DEEP', qr/$re/, '{^ab ^are de} /i matches DEEP' );
 }
 
 {
-    my $re = Regexp::Assemble->new->add( '\\Qabc.def.ghi\\E' );
-    cmp_ok( $re->{stats_add},    '==', 1, "stats add qm" );
-    cmp_ok( $re->{stats_raw},    '==', 15, "stats raw qm" );
-    cmp_ok( $re->{stats_cooked}, '==', 13, "stats cooked qm" );
-    ok( !defined($re->{stats_dup}), "stats dup qm" );
+	my $re = Regexp::Assemble->new->add( qw/abc def ghi/ );
+	cmp_ok( $re->{stats_add},    '==', 3, "stats add 3x3" );
+	cmp_ok( $re->{stats_raw},    '==', 9, "stats raw 3x3" );
+	cmp_ok( $re->{stats_cooked}, '==', 9, "stats cooked 3x3" );
+	ok( !defined($re->{stats_dup}), "stats dup 3x3" );
+
+	$re->add( 'de' );
+	cmp_ok( $re->{stats_add},    '==',  4, "stats add 3x3 +1" );
+	cmp_ok( $re->{stats_raw},    '==', 11, "stats raw 3x3 +1" );
+	cmp_ok( $re->{stats_cooked}, '==', 11, "stats cooked 3x3 +1" );
 }
 
 {
-    my $re = Regexp::Assemble->new->add( 'abc\\,def', 'abc\\,def' );
-    cmp_ok( $re->{stats_add},    '==',  1, "stats add unqm dup" );
-    cmp_ok( $re->{stats_raw},    '==', 16, "stats raw unqm dup" );
-    cmp_ok( $re->{stats_cooked}, '==',  7, "stats cooked unqm dup" );
-    cmp_ok( $re->{stats_dup},    '==',  1, "stats dup unqm dup" );
-    cmp_ok( $re->stats_length,   '==',  0, "stats_length unqm dup" );
-
-    my $str = $re->as_string;
-    cmp_ok( $str, 'eq', 'abc,def', "stats str unqm dup" );
-    cmp_ok( $re->stats_length, '==', 7, "stats len unqm dup" );
+	my $re = Regexp::Assemble->new->add( '\\Qabc.def.ghi\\E' );
+	cmp_ok( $re->{stats_add},    '==', 1, "stats add qm" );
+	cmp_ok( $re->{stats_raw},    '==', 15, "stats raw qm" );
+	cmp_ok( $re->{stats_cooked}, '==', 13, "stats cooked qm" );
+	ok( !defined($re->{stats_dup}), "stats dup qm" );
 }
 
 {
-    my $re = Regexp::Assemble->new->add( '' );
-    cmp_ok( $re->{stats_add}, '==', 1, "stats add empty" );
-    cmp_ok( $re->{stats_raw}, '==', 0, "stats raw empty" );
-    ok( !defined($re->{stats_cooked}), "stats cooked empty" );
-    ok( !defined($re->{stats_dup}),    "stats dup empty" );
+	my $re = Regexp::Assemble->new->add( 'abc\\,def', 'abc\\,def' );
+	cmp_ok( $re->{stats_add},    '==',  1, "stats add unqm dup" );
+	cmp_ok( $re->{stats_raw},    '==', 16, "stats raw unqm dup" );
+	cmp_ok( $re->{stats_cooked}, '==',  7, "stats cooked unqm dup" );
+	cmp_ok( $re->{stats_dup},    '==',  1, "stats dup unqm dup" );
+	cmp_ok( $re->stats_length,   '==',  0, "stats_length unqm dup" );
+
+	my $str = $re->as_string;
+	cmp_ok( $str, 'eq', 'abc,def', "stats str unqm dup" );
+	cmp_ok( $re->stats_length, '==', 7, "stats len unqm dup" );
 }
 
 {
-    my $re = Regexp::Assemble->new;
-    cmp_ok( $re->stats_add,    '==', 0, "stats_add empty" );
-    cmp_ok( $re->stats_raw,    '==', 0, "stats_raw empty" );
-    cmp_ok( $re->stats_cooked, '==', 0, "stats_cooked empty" );
-    cmp_ok( $re->stats_dup,    '==', 0, "stats_dup empty" );
-    cmp_ok( $re->stats_length, '==', 0, "stats_length empty" );
-
-    my $str = $re->as_string;
-    cmp_ok( $str, 'eq', $Regexp::Assemble::Always_Fail, "stats str empty" ); # tricky!
-    cmp_ok( $re->stats_length, '==', 0, "stats len empty" );
+	my $re = Regexp::Assemble->new->add( '' );
+	cmp_ok( $re->{stats_add}, '==', 1, "stats add empty" );
+	cmp_ok( $re->{stats_raw}, '==', 0, "stats raw empty" );
+	ok( !defined($re->{stats_cooked}), "stats cooked empty" );
+	ok( !defined($re->{stats_dup}),    "stats dup empty" );
 }
 
 {
-    my $re = Regexp::Assemble->new->add( '\\Q.+\\E', '\\Q.+\\E', '\\Q.*\\E' );
-    cmp_ok( $re->stats_add,    '==',  2, "stats_add 2" );
-    cmp_ok( $re->stats_raw,    '==', 18, "stats_raw 2" );
-    cmp_ok( $re->stats_cooked, '==',  8, "stats_cooked 2" );
-    cmp_ok( $re->stats_dup,    '==',  1, "stats_dup 2" );
-    cmp_ok( $re->stats_length, '==',  0, "stats_length 2" );
+	my $re = Regexp::Assemble->new;
+	cmp_ok( $re->stats_add,    '==', 0, "stats_add empty" );
+	cmp_ok( $re->stats_raw,    '==', 0, "stats_raw empty" );
+	cmp_ok( $re->stats_cooked, '==', 0, "stats_cooked empty" );
+	cmp_ok( $re->stats_dup,    '==', 0, "stats_dup empty" );
+	cmp_ok( $re->stats_length, '==', 0, "stats_length empty" );
 
-    my $str = $re->as_string;
-    cmp_ok( $str, 'eq', '\\.[*+]', "stats str 2" );
-    cmp_ok( $re->stats_length, '==', 6, "stats len 2 <$str>" );
+	my $str = $re->as_string;
+	cmp_ok( $str, 'eq', $Regexp::Assemble::Always_Fail, "stats str empty" ); # tricky!
+	cmp_ok( $re->stats_length, '==', 0, "stats len empty" );
 }
 
 {
-    # CPAN bug #24171
-    # given a list of strings
-    my @str = ( 'a b', 'awb', 'a1b', 'bar', "a\nb" );
+	my $re = Regexp::Assemble->new->add( '\\Q.+\\E', '\\Q.+\\E', '\\Q.*\\E' );
+	cmp_ok( $re->stats_add,    '==',  2, "stats_add 2" );
+	cmp_ok( $re->stats_raw,    '==', 18, "stats_raw 2" );
+	cmp_ok( $re->stats_cooked, '==',  8, "stats_cooked 2" );
+	cmp_ok( $re->stats_dup,    '==',  1, "stats_dup 2" );
+	cmp_ok( $re->stats_length, '==',  0, "stats_length 2" );
 
-    for my $meta (qw( s w d )) {
-
-        # given a list of patterns
-        my @re = ( "a\\${meta}b", "a\\@{[uc$meta]}b" );
-
-        # produce an assembled pattern
-        my $re = Regexp::Assemble->new()->add(@re)->re();
-
-        my $re_fold = Regexp::Assemble->new()->fold_meta_pairs(0)->add(@re)->re();
-
-        # test it against the strings
-        for my $str (@str) {
-
-            # any match?
-            my $ok = 0;
-            $str =~ $_ && ( $ok = 1 ) for @re;
-
-            # does the assemble regexp match as well?
-            my $ptr = $str;
-            $ptr =~ s/\\/\\\\/;
-            $ptr =~ s/\n/\\n/;
-
-            my $bug_success = ($str =~ /\n/) ? 0 : 1;
-            my $bug_fail    = 1 - $bug_success;
-
-            is( ($str =~ $re) ? $bug_success : $bug_fail, $ok,
-                "Folded meta pairs behave as list for \\$meta ($ptr,ok=$ok/$bug_success/$bug_fail)"
-            );
-
-            is( ($str =~ $re_fold) ? 1 : 0, $ok,
-                "Unfolded meta pairs behave as list for \\$meta ($ptr,ok=$ok)"
-            );
-
-        }
-    }
+	my $str = $re->as_string;
+	cmp_ok( $str, 'eq', '\\.[*+]', "stats str 2" );
+	cmp_ok( $re->stats_length, '==', 6, "stats len 2 <$str>" );
 }
 
 {
-    my $u = Regexp::Assemble->new(unroll_plus => 1);
-    my $str;
+	# CPAN bug #24171
+	# given a list of strings
+	my @str = ( 'a b', 'awb', 'a1b', 'bar', "a\nb" );
 
-    $u->add( "a+b", 'ac' );
-    $str = $u->as_string;
-    is( $str, 'a(?:a*b|c)', 'unroll plus a+b ac' );
+	for my $meta (qw( s w d )) {
 
-    $u->add( "\\LA+B", "ac" );
-    $str = $u->as_string;
-    is( $str, 'a(?:a*b|c)', 'unroll plus \\LA+B ac' );
+		# given a list of patterns
+		my @re = ( "a\\${meta}b", "a\\@{[uc$meta]}b" );
 
-    $u->add( '\\Ua+?b', "AC" );
-    $str = $u->as_string;
-    is( $str, 'A(?:A*?B|C)', 'unroll plus \\Ua+?b AC' );
+		# produce an assembled pattern
+		my $re = Regexp::Assemble->new()->add(@re)->re();
 
-    $u->add( qw(\\d+d \\de \\w+?x \\wy ));
-    $str = $u->as_string;
-    is( $str, '(?:\\w(?:\\w*?x|y)|\\d(?:\d*d|e))', 'unroll plus \\d and \\w' );
+		my $re_fold = Regexp::Assemble->new()->fold_meta_pairs(0)->add(@re)->re();
 
-    $u->add( qw( \\xab+f \\xabg \\xcd+?h \\xcdi ));
-    $str = $u->as_string;
-    is( $str, "(?:\xcd(?:\xcd*?h|i)|\xab(?:\xab*f|g))", 'unroll plus meta x' );
+		# test it against the strings
+		for my $str (@str) {
 
-    $u->add( qw([a-e]+h [a-e]i [f-j]+?k [f-j]m ));
-    $str = $u->as_string;
-    is( $str, "(?:[f-j](?:[f-j]*?k|m)|[a-e](?:[a-e]*h|i))", 'unroll plus class' );
+			# any match?
+			my $ok = 0;
+			$str =~ $_ && ( $ok = 1 ) for @re;
 
-    $u->add( "a+b" );
-    $str = $u->as_string;
-    is( $str, "a+b", 'reroll a+b' );
+			# does the assemble regexp match as well?
+			my $ptr = $str;
+			$ptr =~ s/\\/\\\\/;
+			$ptr =~ s/\n/\\n/;
 
-    $u->add( "a+b", "a+" );
-    $str = $u->as_string;
-    is( $str, "a+b?", 'reroll a+b?' );
+			my $bug_success = ($str =~ /\n/) ? 0 : 1;
+			my $bug_fail    = 1 - $bug_success;
 
-    $u->add( "a+?b", "a+?" );
-    $str = $u->as_string;
-    is( $str, "a+?b?", 'reroll a+?b?' );
+			is( ($str =~ $re) ? $bug_success : $bug_fail, $ok,
+				"Folded meta pairs behave as list for \\$meta ($ptr,ok=$ok/$bug_success/$bug_fail)"
+			);
 
-    $u->unroll_plus(0)->add( qw(1+2 13) );
-    $str = $u->as_string;
-    is( $str, "(?:1+2|13)", 'no unrolling' );
+			is( ($str =~ $re_fold) ? 1 : 0, $ok,
+				"Unfolded meta pairs behave as list for \\$meta ($ptr,ok=$ok)"
+			);
 
-    $u->unroll_plus()->add( qw(1+2 13) );
-    $str = $u->as_string;
-    is( $str, "1(?:1*2|3)", 'unrolling again via implicit' );
+		}
+	}
+}
 
-    $u->add(qw(d+ldrt d+ndrt d+ldt d+ndt d+x));
-    $str = $u->as_string;
-    is( $str, 'd+(?:[ln]dr?t|x)', 'visit ARRAY codepath' );
+{
+	my $u = Regexp::Assemble->new(unroll_plus => 1);
+	my $str;
+
+	$u->add( "a+b", 'ac' );
+	$str = $u->as_string;
+	is( $str, 'a(?:a*b|c)', 'unroll plus a+b ac' );
+
+	$u->add( "\\LA+B", "ac" );
+	$str = $u->as_string;
+	is( $str, 'a(?:a*b|c)', 'unroll plus \\LA+B ac' );
+
+	$u->add( '\\Ua+?b', "AC" );
+	$str = $u->as_string;
+	is( $str, 'A(?:A*?B|C)', 'unroll plus \\Ua+?b AC' );
+
+	$u->add( qw(\\d+d \\de \\w+?x \\wy ));
+	$str = $u->as_string;
+	is( $str, '(?:\\w(?:\\w*?x|y)|\\d(?:\d*d|e))', 'unroll plus \\d and \\w' );
+
+	$u->add( qw( \\xab+f \\xabg \\xcd+?h \\xcdi ));
+	$str = $u->as_string;
+	is( $str, "(?:\xcd(?:\xcd*?h|i)|\xab(?:\xab*f|g))", 'unroll plus meta x' );
+
+	$u->add( qw([a-e]+h [a-e]i [f-j]+?k [f-j]m ));
+	$str = $u->as_string;
+	is( $str, "(?:[f-j](?:[f-j]*?k|m)|[a-e](?:[a-e]*h|i))", 'unroll plus class' );
+
+	$u->add( "a+b" );
+	$str = $u->as_string;
+	is( $str, "a+b", 'reroll a+b' );
+
+	$u->add( "a+b", "a+" );
+	$str = $u->as_string;
+	is( $str, "a+b?", 'reroll a+b?' );
+
+	$u->add( "a+?b", "a+?" );
+	$str = $u->as_string;
+	is( $str, "a+?b?", 'reroll a+?b?' );
+
+	$u->unroll_plus(0)->add( qw(1+2 13) );
+	$str = $u->as_string;
+	is( $str, "(?:1+2|13)", 'no unrolling' );
+
+	$u->unroll_plus()->add( qw(1+2 13) );
+	$str = $u->as_string;
+	is( $str, "1(?:1*2|3)", 'unrolling again via implicit' );
+
+	$u->add(qw(d+ldrt d+ndrt d+ldt d+ndt d+x));
+	$str = $u->as_string;
+	is( $str, 'd+(?:[ln]dr?t|x)', 'visit ARRAY codepath' );
 }
 
 cmp_ok( $_, 'eq', $fixed, '$_ has not been altered' );

--- a/t/07_warning.t
+++ b/t/07_warning.t
@@ -9,63 +9,63 @@ use constant WARN_TESTS => 6;
 
 eval qq{use Test::More tests => WARN_TESTS};
 if( $@ ) {
-    warn "# Test::More not available, no tests performed\n";
-    print "1..1\nok 1\n";
-    exit 0;
+	warn "# Test::More not available, no tests performed\n";
+	print "1..1\nok 1\n";
+	exit 0;
 }
 
 my $have_Test_Warn;
 BEGIN {
-    $have_Test_Warn = do {
-        eval "use Test::Warn";
-        $@ ? 0 : 1;
-    };
+	$have_Test_Warn = do {
+		eval "use Test::Warn";
+		$@ ? 0 : 1;
+	};
 }
 
 use Regexp::Assemble;
 
 SKIP: {
-    skip( 'Test::Warn not installed on this system', WARN_TESTS )
-        unless $have_Test_Warn;
+	skip( 'Test::Warn not installed on this system', WARN_TESTS )
+		unless $have_Test_Warn;
 
-     my $ra = Regexp::Assemble->new( dup_warn => 1 )
-         ->add( qw( abc def ghi ));
+	 my $ra = Regexp::Assemble->new( dup_warn => 1 )
+		 ->add( qw( abc def ghi ));
 
-     my $rax = Regexp::Assemble->new( dup_warn => 0 )
-         ->add( qw( abc def ghi ));
+	 my $rax = Regexp::Assemble->new( dup_warn => 0 )
+		 ->add( qw( abc def ghi ));
 
-     my $ram = Regexp::Assemble->new->dup_warn
-         ->add( qw( abc def ghi ));
+	 my $ram = Regexp::Assemble->new->dup_warn
+		 ->add( qw( abc def ghi ));
 
-    warning_is { $rax->add( 'def' ) } { carped => "" }, "do not carp explicit";
+	warning_is { $rax->add( 'def' ) } { carped => "" }, "do not carp explicit";
 
-    SKIP: {
-        skip( "Sub::Uplevel version $Sub::Uplevel::VERSION broken on 5.8.8, 0.13 or better required", 2 )
-            if $] == 5.008008 and $Sub::Uplevel::VERSION < 0.13;
+	SKIP: {
+		skip( "Sub::Uplevel version $Sub::Uplevel::VERSION broken on 5.8.8, 0.13 or better required", 2 )
+			if $] == 5.008008 and $Sub::Uplevel::VERSION < 0.13;
 
-        warning_like { $ra->add('def') } qr(duplicate pattern added: /def/ at \S+ line \d+\s*),
-            "carp duplicate pattern, warn from new";
+		warning_like { $ra->add('def') } qr(duplicate pattern added: /def/ at \S+ line \d+\s*),
+			"carp duplicate pattern, warn from new";
 
-        warning_like { $ram->add('abc') } qr(duplicate pattern added: /abc/ at \S+ line \d+\s*),
-            "carp duplicate pattern, warn from method";
-    }
+		warning_like { $ram->add('abc') } qr(duplicate pattern added: /abc/ at \S+ line \d+\s*),
+			"carp duplicate pattern, warn from method";
+	}
 
-    $ra->dup_warn(0);
-    warning_is { $ra->add( 'ghi' ) } { carped => "" }, "do not carp";
-    $ra->dup_warn(1);
+	$ra->dup_warn(0);
+	warning_is { $ra->add( 'ghi' ) } { carped => "" }, "do not carp";
+	$ra->dup_warn(1);
 
-    my $dup_count = 0;
-    $ra->dup_warn( sub { ++$dup_count } );
-    $ra->add( 'abc' );
-    cmp_ok( $dup_count, 'eq', 1, 'dup callback' );
+	my $dup_count = 0;
+	$ra->dup_warn( sub { ++$dup_count } );
+	$ra->add( 'abc' );
+	cmp_ok( $dup_count, 'eq', 1, 'dup callback' );
 
-    $ra->dup_warn(
-        sub {
-            warn join('-', @{$_[-1]})
-        }
-    );
-    $ra->add( 'dup' );
-    warning_is { $ra->add( 'dup' ) } 'd-u-p',
-        "custom carp duplicate pattern";
+	$ra->dup_warn(
+		sub {
+			warn join('-', @{$_[-1]})
+		}
+	);
+	$ra->add( 'dup' );
+	warning_is { $ra->add( 'dup' ) } 'd-u-p',
+		"custom carp duplicate pattern";
 
 } # SKIP

--- a/t/08_track.t
+++ b/t/08_track.t
@@ -10,9 +10,9 @@ use constant TESTS => 75;
 
 eval qq{use Test::More tests => TESTS + 4};
 if( $@ ) {
-    warn "# Test::More not available, no tests performed\n";
-    print "1..1\nok 1\n";
-    exit 0;
+	warn "# Test::More not available, no tests performed\n";
+	print "1..1\nok 1\n";
+	exit 0;
 }
 
 my $PERL_VERSION_TOO_LOW = ($] < 5.007);
@@ -29,206 +29,206 @@ is_deeply( $ra->mbegin, [], 'mbegin is [] on non-tracked R::A object' );
 is_deeply( $ra->mend,   [], 'mend is [] on non-tracked R::A object' );
 
 {
-    my $re = Regexp::Assemble->new
-        ->add( 'cat' )
-        ->add( 'dog' )
-    ;
-    my $regexp = $re->re;
-    ok( $re->match( 'cat' ), 'match without tracking' );
-    ok( !defined( $re->match( 'eagle' )), 'match fail without tracking' );
+	my $re = Regexp::Assemble->new
+		->add( 'cat' )
+		->add( 'dog' )
+	;
+	my $regexp = $re->re;
+	ok( $re->match( 'cat' ), 'match without tracking' );
+	ok( !defined( $re->match( 'eagle' )), 'match fail without tracking' );
 }
 
 {
-    my $re = Regexp::Assemble->new->track(1)->add(q(dog));
-    ok( $re->match('dog'), 're pattern-0 dog match' );
-    is( $re->source(0), 'dog', 'source is dog' );
+	my $re = Regexp::Assemble->new->track(1)->add(q(dog));
+	ok( $re->match('dog'), 're pattern-0 dog match' );
+	is( $re->source(0), 'dog', 'source is dog' );
 
-    $re = Regexp::Assemble->new( track=>1 )
-        ->add( qw/dog dogged fish fetish flash fresh/ );
-    $re->add('foolish-\\d+');
-    ok( $re->match('dog'), 're pattern-1 dog match' );
-    SKIP: {
-        skip( "matched() is not implemented in this version of perl ($])", 1 ) if $PERL_VERSION_TOO_LOW;
-        cmp_ok( $re->matched, 'eq', 'dog', 're pattern-1 dog matched' );
-    }
-    ok( $re->match('dogged'), 're pattern-1 dogged match' );
-    SKIP: {
-        skip( "matched() is not implemented in this version of perl ($])", 1 ) if $PERL_VERSION_TOO_LOW;
-        cmp_ok( $re->matched, 'eq', 'dogged', 're pattern-1 dogged matched' );
-    }
-    ok( $re->match('fetish'), 're pattern-1 fetish match' );
-    SKIP: {
-        skip( "matched() is not implemented in this version of perl ($])", 1 ) if $PERL_VERSION_TOO_LOW;
-        cmp_ok( $re->matched, 'eq', 'fetish', 're pattern-1 fetish matched' );
-    }
-    ok( $re->match('foolish-245'), 're pattern-1 foolish-\\d+ match' );
-    SKIP: {
-        skip( "matched() is not implemented in this version of perl ($])", 2 ) if $PERL_VERSION_TOO_LOW;
-        cmp_ok( $re->matched, 'eq', 'foolish-\\d+', 're pattern-1 foolish-\\d+ matched' );
-        is ($re->source, 'foolish-\\d+', 're pattern-1 foolish source');
-    }
-    ok( !defined($re->match('foolish-')), 're pattern-1 foolish-\\d+ 4' );
-    ok( !defined($re->source), 're pattern-1 foolish-\\d+ source' );
+	$re = Regexp::Assemble->new( track=>1 )
+		->add( qw/dog dogged fish fetish flash fresh/ );
+	$re->add('foolish-\\d+');
+	ok( $re->match('dog'), 're pattern-1 dog match' );
+	SKIP: {
+		skip( "matched() is not implemented in this version of perl ($])", 1 ) if $PERL_VERSION_TOO_LOW;
+		cmp_ok( $re->matched, 'eq', 'dog', 're pattern-1 dog matched' );
+	}
+	ok( $re->match('dogged'), 're pattern-1 dogged match' );
+	SKIP: {
+		skip( "matched() is not implemented in this version of perl ($])", 1 ) if $PERL_VERSION_TOO_LOW;
+		cmp_ok( $re->matched, 'eq', 'dogged', 're pattern-1 dogged matched' );
+	}
+	ok( $re->match('fetish'), 're pattern-1 fetish match' );
+	SKIP: {
+		skip( "matched() is not implemented in this version of perl ($])", 1 ) if $PERL_VERSION_TOO_LOW;
+		cmp_ok( $re->matched, 'eq', 'fetish', 're pattern-1 fetish matched' );
+	}
+	ok( $re->match('foolish-245'), 're pattern-1 foolish-\\d+ match' );
+	SKIP: {
+		skip( "matched() is not implemented in this version of perl ($])", 2 ) if $PERL_VERSION_TOO_LOW;
+		cmp_ok( $re->matched, 'eq', 'foolish-\\d+', 're pattern-1 foolish-\\d+ matched' );
+		is ($re->source, 'foolish-\\d+', 're pattern-1 foolish source');
+	}
+	ok( !defined($re->match('foolish-')), 're pattern-1 foolish-\\d+ 4' );
+	ok( !defined($re->source), 're pattern-1 foolish-\\d+ source' );
 
-    SKIP: {
-        skip( "matched() is not implemented in this version of perl ($])", 1 ) if $PERL_VERSION_TOO_LOW;
-        ok( !defined($re->matched), 're pattern-1 foolish-\\d+ 5' );
-    }
-    if ($] < 5.009005) {
-        ok( do {use re 'eval'; 'cat' !~ /$re/}, 're pattern-1 cat <5.10' );
-        ok( do {use re 'eval'; 'foolish-808' =~ /$re/}, 're pattern-1 foolish-808 <5.10' );
-    }
-    else {
-        ok( 'cat' !~ /$re/, 're pattern-1 cat 5.10' );
-        ok(  'foolish-808' =~ /$re/, 're pattern-1 foolish-808 5.10' );
-    }
+	SKIP: {
+		skip( "matched() is not implemented in this version of perl ($])", 1 ) if $PERL_VERSION_TOO_LOW;
+		ok( !defined($re->matched), 're pattern-1 foolish-\\d+ 5' );
+	}
+	if ($] < 5.009005) {
+		ok( do {use re 'eval'; 'cat' !~ /$re/}, 're pattern-1 cat <5.10' );
+		ok( do {use re 'eval'; 'foolish-808' =~ /$re/}, 're pattern-1 foolish-808 <5.10' );
+	}
+	else {
+		ok( 'cat' !~ /$re/, 're pattern-1 cat 5.10' );
+		ok(  'foolish-808' =~ /$re/, 're pattern-1 foolish-808 5.10' );
+	}
 }
 
 {
-    my $re = Regexp::Assemble->new( track=>1 )
-        ->add( '^a-\\d+$' )
-        ->add( '^a-\\d+-\\d+$' );
-    my $str = $re->as_string;
-    SKIP: {
-        skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 2 ) if $PERL_VERSION_5_005;
-        ok( !defined $re->match('foo'), 'match pattern-2 foo' );
-        ok( defined($re->match('a-22-44')), 'match pattern-2 a-22-44' );
-    }
-    SKIP: {
-           skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 1 ) if $PERL_VERSION_5_005;
-        cmp_ok( $re->match('a-22-55555'), 'eq', '^a-\\d+-\\d+$', 're pattern-2 a-22-55555' );
-    }
-    SKIP: {
-        skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 1 ) if $PERL_VERSION_5_005;
-        ok( $re->match('a-000'), 're pattern-2 a-000 match' );
-    }
-    SKIP: {
-        skip( "matched() is not implemented in this version of perl ($])", 1 ) if $PERL_VERSION_TOO_LOW;
-        cmp_ok( $re->matched, 'eq', '^a-\\d+$', 're pattern-2 a-000 matched' );
-    }
+	my $re = Regexp::Assemble->new( track=>1 )
+		->add( '^a-\\d+$' )
+		->add( '^a-\\d+-\\d+$' );
+	my $str = $re->as_string;
+	SKIP: {
+		skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 2 ) if $PERL_VERSION_5_005;
+		ok( !defined $re->match('foo'), 'match pattern-2 foo' );
+		ok( defined($re->match('a-22-44')), 'match pattern-2 a-22-44' );
+	}
+	SKIP: {
+		   skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 1 ) if $PERL_VERSION_5_005;
+		cmp_ok( $re->match('a-22-55555'), 'eq', '^a-\\d+-\\d+$', 're pattern-2 a-22-55555' );
+	}
+	SKIP: {
+		skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 1 ) if $PERL_VERSION_5_005;
+		ok( $re->match('a-000'), 're pattern-2 a-000 match' );
+	}
+	SKIP: {
+		skip( "matched() is not implemented in this version of perl ($])", 1 ) if $PERL_VERSION_TOO_LOW;
+		cmp_ok( $re->matched, 'eq', '^a-\\d+$', 're pattern-2 a-000 matched' );
+	}
 }
 
 {
-    my $re = Regexp::Assemble->new( track=>1 )
-        ->add( '^b-(\\d+)$' )
-        ->add( '^b-(\\d+)-(\\d+)$' )
-    ;
-    SKIP: {
-        skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 12 ) if $PERL_VERSION_5_005;
-        ok( !defined $re->match('foo'), 'match pattern-3 foo' );
-        ok( defined $re->match('b-34-56'), 'match pattern-3 b-34-56' );
-        cmp_ok( $re->mvar(0), 'eq', 'b-34-56', 'match pattern-3 capture 1' );
-        cmp_ok( $re->mvar(1), '==', 34, 'match pattern-3 capture 2' );
-        cmp_ok( $re->mvar(2), '==', 56, 'match pattern-3 capture 3' );
-        is_deeply( $re->mvar, ['b-34-56', 34, 56], 'match pattern-3 mvar' );
-        is_deeply( $re->mbegin, [0, 2, 5], 'match pattern-3 mbegin' );
-        is_deeply( $re->mend, [7, 4, 7], 'match pattern-3 ' );
-        ok( defined $re->match('b-789'), 'match pattern-3 b-789' );
-        cmp_ok( $re->mvar(0), 'eq', 'b-789', 'match pattern-3 capture 4' );
-        cmp_ok( $re->mvar(1), '==', 789, 'match pattern-3 capture 5' );
-        ok( !defined($re->mvar(2)), 'match pattern-3 undef' );
-    }
+	my $re = Regexp::Assemble->new( track=>1 )
+		->add( '^b-(\\d+)$' )
+		->add( '^b-(\\d+)-(\\d+)$' )
+	;
+	SKIP: {
+		skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 12 ) if $PERL_VERSION_5_005;
+		ok( !defined $re->match('foo'), 'match pattern-3 foo' );
+		ok( defined $re->match('b-34-56'), 'match pattern-3 b-34-56' );
+		cmp_ok( $re->mvar(0), 'eq', 'b-34-56', 'match pattern-3 capture 1' );
+		cmp_ok( $re->mvar(1), '==', 34, 'match pattern-3 capture 2' );
+		cmp_ok( $re->mvar(2), '==', 56, 'match pattern-3 capture 3' );
+		is_deeply( $re->mvar, ['b-34-56', 34, 56], 'match pattern-3 mvar' );
+		is_deeply( $re->mbegin, [0, 2, 5], 'match pattern-3 mbegin' );
+		is_deeply( $re->mend, [7, 4, 7], 'match pattern-3 ' );
+		ok( defined $re->match('b-789'), 'match pattern-3 b-789' );
+		cmp_ok( $re->mvar(0), 'eq', 'b-789', 'match pattern-3 capture 4' );
+		cmp_ok( $re->mvar(1), '==', 789, 'match pattern-3 capture 5' );
+		ok( !defined($re->mvar(2)), 'match pattern-3 undef' );
+	}
 }
 
 {
-    my $re = Regexp::Assemble->new( track=>1 )
-        ->add( '^c-(\\d+)$' )
-        ->add( '^c-(\\w+)$' )
-        ->add( '^c-([aeiou])-(\\d+)$' )
-    ;
-    SKIP: {
-        skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 12 ) if $PERL_VERSION_5_005;
-        ok( !defined $re->match('foo'), 'match pattern-4 foo' );
-        ok( !defined $re->mvar(2), 'match pattern-4 foo novar' );
-        my $target = 'c-u-350';
-        ok( defined $re->match($target), "match pattern-4 $target" );
-        ok( $re->mvar(0) eq $target, 'match pattern-4 capture 1' );
-        ok( $re->mvar(1) eq 'u', 'match pattern-4 capture 2' );
-        ok( $re->mvar(2) == 350, 'match pattern-4 capture 3' );
-        $target = 'c-2048';
-        ok( defined $re->match($target), "match pattern-4 $target" );
-        ok( $re->mvar(0) eq $target, 'match pattern-4 capture 4' );
-        ok( $re->mvar(1) == 2048, 'match pattern-4 capture 5' );
-        ok( !defined($re->mvar(2)), 'match pattern-4 undef' );
-        is_deeply( $re->mbegin, [0, undef, undef, 2], 'match pattern-3 mbegin' );
-        is_deeply( $re->mend, [6, undef, undef, 6, undef], 'match pattern-3 mend' );
-    }
+	my $re = Regexp::Assemble->new( track=>1 )
+		->add( '^c-(\\d+)$' )
+		->add( '^c-(\\w+)$' )
+		->add( '^c-([aeiou])-(\\d+)$' )
+	;
+	SKIP: {
+		skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 12 ) if $PERL_VERSION_5_005;
+		ok( !defined $re->match('foo'), 'match pattern-4 foo' );
+		ok( !defined $re->mvar(2), 'match pattern-4 foo novar' );
+		my $target = 'c-u-350';
+		ok( defined $re->match($target), "match pattern-4 $target" );
+		ok( $re->mvar(0) eq $target, 'match pattern-4 capture 1' );
+		ok( $re->mvar(1) eq 'u', 'match pattern-4 capture 2' );
+		ok( $re->mvar(2) == 350, 'match pattern-4 capture 3' );
+		$target = 'c-2048';
+		ok( defined $re->match($target), "match pattern-4 $target" );
+		ok( $re->mvar(0) eq $target, 'match pattern-4 capture 4' );
+		ok( $re->mvar(1) == 2048, 'match pattern-4 capture 5' );
+		ok( !defined($re->mvar(2)), 'match pattern-4 undef' );
+		is_deeply( $re->mbegin, [0, undef, undef, 2], 'match pattern-3 mbegin' );
+		is_deeply( $re->mend, [6, undef, undef, 6, undef], 'match pattern-3 mend' );
+	}
 }
 
 {
-    my $re = Regexp::Assemble->new( track=>1 )
-        ->add( '^c-\\d+$' )
-        ->add( '^c-\\w+$' )
-        ->add( '^c-[aeiou]-\\d+$' )
-    ;
-    SKIP: {
-        skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 6 ) if $PERL_VERSION_5_005;
-        ok( !defined $re->match('foo'), 'match pattern-5 foo' );
-        ok( !defined $re->mvar(2), 'match pattern-4 foo novar' );
-        my $target = 'c-u-350';
-        ok( defined $re->match($target), "match pattern-5 $target" );
-        ok( $re->mvar(0) eq $target, 'match pattern-5' );
-        ok( !defined $re->mvar(1), 'match pattern-5 no capture 2' );
-        ok( !defined $re->mvar(2), 'match pattern-5 no capture 3' );
-    }
+	my $re = Regexp::Assemble->new( track=>1 )
+		->add( '^c-\\d+$' )
+		->add( '^c-\\w+$' )
+		->add( '^c-[aeiou]-\\d+$' )
+	;
+	SKIP: {
+		skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 6 ) if $PERL_VERSION_5_005;
+		ok( !defined $re->match('foo'), 'match pattern-5 foo' );
+		ok( !defined $re->mvar(2), 'match pattern-4 foo novar' );
+		my $target = 'c-u-350';
+		ok( defined $re->match($target), "match pattern-5 $target" );
+		ok( $re->mvar(0) eq $target, 'match pattern-5' );
+		ok( !defined $re->mvar(1), 'match pattern-5 no capture 2' );
+		ok( !defined $re->mvar(2), 'match pattern-5 no capture 3' );
+	}
 }
 
 {
-    my $re = Regexp::Assemble->new( track=>1 )
-        ->add( '^cat' )
-        ->add( '^candle$' )
-        ->flags( 'i' )
-    ;
-    SKIP: {
-           skip( "match()/matched() return undef in this version of perl ($])", 8 ) if $PERL_VERSION_5_005;
-        ok( !defined $re->match('foo'), 'not match pattern-6 foo' );
-        my $target = 'cat';
-        ok( defined $re->match($target), "match pattern-6 $target" );
-        cmp_ok( $re->matched, 'eq', '^cat', "match pattern-6 $target re" );
-        $target = 'CATFOOD';
-        ok( defined $re->match($target), "match pattern-6 $target" );
-        cmp_ok( $re->matched, 'eq', '^cat', "match pattern-6 $target re" );
-        $target = 'candle';
-        ok( defined $re->match($target), "match pattern-6 $target" );
-        cmp_ok( $re->matched, 'eq', '^candle$', "match pattern-6 $target re" );
-        $target = 'Candlestick';
-        ok( !defined $re->match($target), "match pattern-6 $target" );
-    }
+	my $re = Regexp::Assemble->new( track=>1 )
+		->add( '^cat' )
+		->add( '^candle$' )
+		->flags( 'i' )
+	;
+	SKIP: {
+		   skip( "match()/matched() return undef in this version of perl ($])", 8 ) if $PERL_VERSION_5_005;
+		ok( !defined $re->match('foo'), 'not match pattern-6 foo' );
+		my $target = 'cat';
+		ok( defined $re->match($target), "match pattern-6 $target" );
+		cmp_ok( $re->matched, 'eq', '^cat', "match pattern-6 $target re" );
+		$target = 'CATFOOD';
+		ok( defined $re->match($target), "match pattern-6 $target" );
+		cmp_ok( $re->matched, 'eq', '^cat', "match pattern-6 $target re" );
+		$target = 'candle';
+		ok( defined $re->match($target), "match pattern-6 $target" );
+		cmp_ok( $re->matched, 'eq', '^candle$', "match pattern-6 $target re" );
+		$target = 'Candlestick';
+		ok( !defined $re->match($target), "match pattern-6 $target" );
+	}
 }
 
 {
-    my @capture;
-    my $re = Regexp::Assemble->new( track=>1 )
-        ->add( '^ab-(\d+)-(\d+)' )
-        ->add( '^ac-(\d+)' )
-        ->add( '^nothing' )
-        ->add( '^ad-((\d+)-(\d+))' )
-    ;
-    SKIP: {
-        skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 15 ) if $PERL_VERSION_5_005;
-        ok( !defined($re->capture), 'match p7 no prior capture' );
+	my @capture;
+	my $re = Regexp::Assemble->new( track=>1 )
+		->add( '^ab-(\d+)-(\d+)' )
+		->add( '^ac-(\d+)' )
+		->add( '^nothing' )
+		->add( '^ad-((\d+)-(\d+))' )
+	;
+	SKIP: {
+		skip( "/?{...}/ and \\d+ cause a panic in this version of perl ($])", 15 ) if $PERL_VERSION_5_005;
+		ok( !defined($re->capture), 'match p7 no prior capture' );
 
-        ok( defined $re->match('nothing captured'), 'match p7-1' );
-        is( scalar($re->capture), 0, 'match p7-1 no capture' );
+		ok( defined $re->match('nothing captured'), 'match p7-1' );
+		is( scalar($re->capture), 0, 'match p7-1 no capture' );
 
-        ok( defined $re->match('ac-417 captured'), 'match p7-2' );
-        @capture = $re->capture;
-        is( scalar(@capture), 1, 'match p7-2 capture' );
-        is( $capture[0], 417, "match p7-2 value 0 ok" );
+		ok( defined $re->match('ac-417 captured'), 'match p7-2' );
+		@capture = $re->capture;
+		is( scalar(@capture), 1, 'match p7-2 capture' );
+		is( $capture[0], 417, "match p7-2 value 0 ok" );
 
-        ok( defined $re->match('ab-21-17 captured'), 'match p7-3' );
-        @capture = $re->capture;
-        is( scalar(@capture), 2, 'match p7-3 capture' );
-        is( $capture[0], 21, "match p7-3 value 0 ok" );
-        is( $capture[1], 17, "match p7-3 value 1 ok" );
+		ok( defined $re->match('ab-21-17 captured'), 'match p7-3' );
+		@capture = $re->capture;
+		is( scalar(@capture), 2, 'match p7-3 capture' );
+		is( $capture[0], 21, "match p7-3 value 0 ok" );
+		is( $capture[1], 17, "match p7-3 value 1 ok" );
 
-        ok( defined $re->match('ad-808-245 captured'), 'match p7-4' );
-        @capture = $re->capture;
-        is( scalar(@capture), 3, 'match p7-4 capture' );
-        is( $capture[0], '808-245', "match p7-4 value 0 ok" );
-        is( $capture[1], 808, "match p7-4 value 1 ok" );
-        is( $capture[2], 245, "match p7-4 value 2 ok" );
-    }
+		ok( defined $re->match('ad-808-245 captured'), 'match p7-4' );
+		@capture = $re->capture;
+		is( scalar(@capture), 3, 'match p7-4 capture' );
+		is( $capture[0], '808-245', "match p7-4 value 0 ok" );
+		is( $capture[1], 808, "match p7-4 value 1 ok" );
+		is( $capture[2], 245, "match p7-4 value 2 ok" );
+	}
 }
 
 cmp_ok( $_, 'eq', $fixed, '$_ has not been altered' );

--- a/t/09_debug.t
+++ b/t/09_debug.t
@@ -9,9 +9,9 @@ use strict;
 
 eval qq{use Test::More tests => 68};
 if( $@ ) {
-    warn "# Test::More not available, no tests performed\n";
-    print "1..1\nok 1\n";
-    exit 0;
+	warn "# Test::More not available, no tests performed\n";
+	print "1..1\nok 1\n";
+	exit 0;
 }
 
 use Regexp::Assemble;
@@ -22,209 +22,209 @@ my $fixed = 'The scalar remains the same';
 $_ = $fixed;
 
 {
-    my $r = Regexp::Assemble->new( debug => 15 );
-    is( $r->{debug}, 15, 'debug new(n)' );
-    $r->debug( 0 );
-    is( $r->{debug}, 0, 'debug(0)' );
-    $r->debug( 4 );
-    is( $r->{debug}, 4, 'debug(4)' );
-    $r->debug();
-    is( $r->{debug}, 0, 'debug()' );
+	my $r = Regexp::Assemble->new( debug => 15 );
+	is( $r->{debug}, 15, 'debug new(n)' );
+	$r->debug( 0 );
+	is( $r->{debug}, 0, 'debug(0)' );
+	$r->debug( 4 );
+	is( $r->{debug}, 4, 'debug(4)' );
+	$r->debug();
+	is( $r->{debug}, 0, 'debug()' );
 }
 
 {
-    my $u = Regexp::Assemble->new(unroll_plus => 1)->debug(4);
-    my $str;
+	my $u = Regexp::Assemble->new(unroll_plus => 1)->debug(4);
+	my $str;
 
-    $u->add( "[a]", );
-    $str = $u->as_string;
-    is( $str, 'a', '[a] -> a' );
+	$u->add( "[a]", );
+	$str = $u->as_string;
+	is( $str, 'a', '[a] -> a' );
 
-    $u->add( "a+b", 'ac' );
-    $str = $u->as_string;
-    is( $str, 'a(?:a*b|c)', 'unroll plus a+b ac' );
+	$u->add( "a+b", 'ac' );
+	$str = $u->as_string;
+	is( $str, 'a(?:a*b|c)', 'unroll plus a+b ac' );
 
-    $u->add( "\\LA+B", "ac" );
-    $str = $u->as_string;
-    is( $str, 'a(?:a*b|c)', 'unroll plus \\LA+B ac' );
+	$u->add( "\\LA+B", "ac" );
+	$str = $u->as_string;
+	is( $str, 'a(?:a*b|c)', 'unroll plus \\LA+B ac' );
 
-    $u->add( '\\Ua+?b', "AC" );
-    $str = $u->as_string;
-    is( $str, 'A(?:A*?B|C)', 'unroll plus \\Ua+?b AC' );
+	$u->add( '\\Ua+?b', "AC" );
+	$str = $u->as_string;
+	is( $str, 'A(?:A*?B|C)', 'unroll plus \\Ua+?b AC' );
 
-    $u->add( "\\d+d", "\\de" );
-    $str = $u->as_string;
-    is( $str, '\\d(?:\d*d|e)', 'unroll plus \\d+d \\de' );
+	$u->add( "\\d+d", "\\de" );
+	$str = $u->as_string;
+	is( $str, '\\d(?:\d*d|e)', 'unroll plus \\d+d \\de' );
 
-    $u->add( "\\xab+f", "\\xabg" );
-    $str = $u->as_string;
-    is( $str, "\xab(?:\xab*f|g)", 'unroll plus \\xab+f \\xabg' );
+	$u->add( "\\xab+f", "\\xabg" );
+	$str = $u->as_string;
+	is( $str, "\xab(?:\xab*f|g)", 'unroll plus \\xab+f \\xabg' );
 
-    $u->add( "[a-e]+h", "[a-e]i" );
-    $str = $u->as_string;
-    is( $str, "[a-e](?:[a-e]*h|i)", 'unroll plus [a-e]+h [a-e]i' );
+	$u->add( "[a-e]+h", "[a-e]i" );
+	$str = $u->as_string;
+	is( $str, "[a-e](?:[a-e]*h|i)", 'unroll plus [a-e]+h [a-e]i' );
 
-    $u->add( "a+b" );
-    $str = $u->as_string;
-    is( $str, "a+b", 'reroll a+b' );
+	$u->add( "a+b" );
+	$str = $u->as_string;
+	is( $str, "a+b", 'reroll a+b' );
 
-    $u->add( "a+b", "a+" );
-    $str = $u->as_string;
-    is( $str, "a+b?", 'reroll a+b?' );
+	$u->add( "a+b", "a+" );
+	$str = $u->as_string;
+	is( $str, "a+b?", 'reroll a+b?' );
 
-    $u->add( "a+?b", "a+?" );
-    $str = $u->as_string;
-    is( $str, "a+?b?", 'reroll a+?b?' );
+	$u->add( "a+?b", "a+?" );
+	$str = $u->as_string;
+	is( $str, "a+?b?", 'reroll a+?b?' );
 
-    $u->add( qw(defused fused used) );
-    $str = $u->as_string;
-    is( $str, "(?:(?:de)?f)?used", 'big debug block in _insert_path()' );
+	$u->add( qw(defused fused used) );
+	$str = $u->as_string;
+	is( $str, "(?:(?:de)?f)?used", 'big debug block in _insert_path()' );
 }
 
 {
-    my $str = '\t+b*c?\\x41';
-    is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str ),
-        [ '\t+', 'b*', 'c?', 'A' ],
-        "_lex $str",
-    );
+	my $str = '\t+b*c?\\x41';
+	is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str ),
+		[ '\t+', 'b*', 'c?', 'A' ],
+		"_lex $str",
+	);
 
-    $str = '\Q[';
-    is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str ),
-        [ '\\[' ],
-        "_lex $str",
-    );
+	$str = '\Q[';
+	is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str ),
+		[ '\\[' ],
+		"_lex $str",
+	);
 
-    $str = '\Q]';
-    is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str ),
-        [ '\\]' ],
-        "_lex $str",
-    );
+	$str = '\Q]';
+	is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str ),
+		[ '\\]' ],
+		"_lex $str",
+	);
 
-    $str = '\Q(';
-    is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str ),
-        [ '\\(' ],
-        "_lex $str",
-    );
+	$str = '\Q(';
+	is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str ),
+		[ '\\(' ],
+		"_lex $str",
+	);
 
-    $str = '\Q)';
-    is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str ),
-        [ '\\)' ],
-        "_lex $str",
-    );
+	$str = '\Q)';
+	is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str ),
+		[ '\\)' ],
+		"_lex $str",
+	);
 
-    $str = '\Qa+b*c?';
-    is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str ),
-        [ 'a', '\+', 'b', '\*', 'c', '\?' ],
-        "_lex $str",
-    );
+	$str = '\Qa+b*c?';
+	is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str ),
+		[ 'a', '\+', 'b', '\*', 'c', '\?' ],
+		"_lex $str",
+	);
 
-    $str = 'a\\LBC\\Ude\\Ef\\Qg+';
-    is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str  ),
-        [ 'a', 'b', 'c', 'D', 'E', 'f', 'g', '\\+' ],
-        "_lex $str",
-    );
+	$str = 'a\\LBC\\Ude\\Ef\\Qg+';
+	is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str  ),
+		[ 'a', 'b', 'c', 'D', 'E', 'f', 'g', '\\+' ],
+		"_lex $str",
+	);
 
-    $str = 'a\\uC';
-    is_deeply( Regexp::Assemble->new(debug => 4) ->_lex( $str  ),
-        [ 'a', 'C' ],
-        "_lex $str",
-    );
+	$str = 'a\\uC';
+	is_deeply( Regexp::Assemble->new(debug => 4) ->_lex( $str  ),
+		[ 'a', 'C' ],
+		"_lex $str",
+	);
 
-    $str = '\Q\/?';
-    is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str  ), [ '\/', '\?' ], "_lex $str" );
+	$str = '\Q\/?';
+	is_deeply( Regexp::Assemble->new->debug(4)->_lex( $str  ), [ '\/', '\?' ], "_lex $str" );
 
-    $str = 'p\\L\\QA+\\EZ';
-    is_deeply( Regexp::Assemble->new->debug(4)->add( $str )->_path,
-        [ 'p', 'a', '\\+', 'Z' ], "add $str" );
+	$str = 'p\\L\\QA+\\EZ';
+	is_deeply( Regexp::Assemble->new->debug(4)->add( $str )->_path,
+		[ 'p', 'a', '\\+', 'Z' ], "add $str" );
 
-    $str = '^\Qa[b[';
-    is_deeply( Regexp::Assemble->new->debug(15)->add( $str )->_path,
-        [ '^', 'a', '\\[', 'b', '\\[' ], "add $str" );
+	$str = '^\Qa[b[';
+	is_deeply( Regexp::Assemble->new->debug(15)->add( $str )->_path,
+		[ '^', 'a', '\\[', 'b', '\\[' ], "add $str" );
 }
 
 {
-    my $r = Regexp::Assemble->new->debug(4)->add('\x45');
-    is_deeply( $r->_path, [ 'E' ], '_lex(\\x45) with debug' );
+	my $r = Regexp::Assemble->new->debug(4)->add('\x45');
+	is_deeply( $r->_path, [ 'E' ], '_lex(\\x45) with debug' );
 }
 
 {
-    my $ra = Regexp::Assemble->new(debug => 1);
-    $ra->insert( undef );
-    is_deeply( $ra->_path, [{'' => undef}], 'insert(undef)' );
+	my $ra = Regexp::Assemble->new(debug => 1);
+	$ra->insert( undef );
+	is_deeply( $ra->_path, [{'' => undef}], 'insert(undef)' );
 }
 
 {
-    my $r = Regexp::Assemble->new(lex => '\\d');
-    is_deeply( $r->debug(4)->add( '67abc123def+' )->_path,
-        [ '6', '7', 'abc', '1', '2', '3', 'def+' ],
-        '67abc123def+ with \\d lexer',
-    );
-    is_deeply( $r->reset->debug(0)->add( '67ab12de+' )->_path,
-        [ '6', '7', 'ab', '1', '2', 'de+' ],
-        '67ab12de+ with \\d lexer',
-    );
+	my $r = Regexp::Assemble->new(lex => '\\d');
+	is_deeply( $r->debug(4)->add( '67abc123def+' )->_path,
+		[ '6', '7', 'abc', '1', '2', '3', 'def+' ],
+		'67abc123def+ with \\d lexer',
+	);
+	is_deeply( $r->reset->debug(0)->add( '67ab12de+' )->_path,
+		[ '6', '7', 'ab', '1', '2', 'de+' ],
+		'67ab12de+ with \\d lexer',
+	);
 }
 
 {
-    my $r = Regexp::Assemble->new(lex => '\\d');
-    is_deeply( $r->debug(4)->add( '67\\Q1a*\\E12jk' )->_path,
-        [ '6', '7', '1', 'a', '\\*', '1', '2', 'jk' ],
-        '67\\Q1a*\\E12jk with \\d lexer',
-    );
+	my $r = Regexp::Assemble->new(lex => '\\d');
+	is_deeply( $r->debug(4)->add( '67\\Q1a*\\E12jk' )->_path,
+		[ '6', '7', '1', 'a', '\\*', '1', '2', 'jk' ],
+		'67\\Q1a*\\E12jk with \\d lexer',
+	);
 }
 
 {
-    my $r = Regexp::Assemble->new(lex => '\\d');
-    is_deeply( $r->debug(4)->add( '67\\Q1a*45k+' )->_path,
-        [ '6', '7', '1', 'a', '\\*', '4', '5', 'k', '\\+' ],
-        '67\\Q1a*45k+ with \\d lexer',
-    );
+	my $r = Regexp::Assemble->new(lex => '\\d');
+	is_deeply( $r->debug(4)->add( '67\\Q1a*45k+' )->_path,
+		[ '6', '7', '1', 'a', '\\*', '4', '5', 'k', '\\+' ],
+		'67\\Q1a*45k+ with \\d lexer',
+	);
 }
 
 {
-    my $r = Regexp::Assemble->new(lex => '\\d');
-    is_deeply( $r->debug(4)->add( '7\U6a' )->_path,
-        [ '7', '6', 'A' ],
-        '7\\U6a with \\d lexer',
-    );
+	my $r = Regexp::Assemble->new(lex => '\\d');
+	is_deeply( $r->debug(4)->add( '7\U6a' )->_path,
+		[ '7', '6', 'A' ],
+		'7\\U6a with \\d lexer',
+	);
 }
 
 {
-    my $r = Regexp::Assemble->new(lex => '\\d');
-    is_deeply( $r->debug(4)->add( '8\L9C' )->_path,
-        [ '8', '9', 'c' ],
-        '8\\L9C with \\d lexer',
-    );
+	my $r = Regexp::Assemble->new(lex => '\\d');
+	is_deeply( $r->debug(4)->add( '8\L9C' )->_path,
+		[ '8', '9', 'c' ],
+		'8\\L9C with \\d lexer',
+	);
 }
 
 {
-    my $r = Regexp::Assemble->new(lex => '\\d');
-    is_deeply( $r->debug(4)->add( '57\\Q2a+23d+' )->_path,
-        [ '5', '7', '2', 'a', '\\+', '2', '3', 'd', '\\+' ],
-        '57\\Q2a+23d+ with \\d lexer',
-    );
+	my $r = Regexp::Assemble->new(lex => '\\d');
+	is_deeply( $r->debug(4)->add( '57\\Q2a+23d+' )->_path,
+		[ '5', '7', '2', 'a', '\\+', '2', '3', 'd', '\\+' ],
+		'57\\Q2a+23d+ with \\d lexer',
+	);
 }
 
 {
-    my $save = $Regexp::Assemble::Default_Lexer;
-    Regexp::Assemble::Default_Lexer('\\d');
-    my $r = Regexp::Assemble->new;
-    is_deeply( $r->debug(4)->add( '67\\Uabc\\E123def' )->_path,
-        [ '6', '7', '\\Uabc\\E', '1', '2', '3', 'def' ],
-        '67\Uabc\\E123def with \\d lexer',
-    );
+	my $save = $Regexp::Assemble::Default_Lexer;
+	Regexp::Assemble::Default_Lexer('\\d');
+	my $r = Regexp::Assemble->new;
+	is_deeply( $r->debug(4)->add( '67\\Uabc\\E123def' )->_path,
+		[ '6', '7', '\\Uabc\\E', '1', '2', '3', 'def' ],
+		'67\Uabc\\E123def with \\d lexer',
+	);
 
-    is_deeply( $r->reset->add( '67\\Q(?:a)?\\E123def' )->_path,
-        [ '6', '7', '\\Q(?:a)?\\E', '1', '2', '3', 'def' ],
-        '67\Uabc\\E123def with \\d lexer',
-    );
+	is_deeply( $r->reset->add( '67\\Q(?:a)?\\E123def' )->_path,
+		[ '6', '7', '\\Q(?:a)?\\E', '1', '2', '3', 'def' ],
+		'67\Uabc\\E123def with \\d lexer',
+	);
 
-    $Regexp::Assemble::Default_Lexer = $save;
+	$Regexp::Assemble::Default_Lexer = $save;
 }
 
 is( Regexp::Assemble->new->debug(1)->add( qw/
-        0\.0 0\.2 0\.7 0\.01 0\.003
-    / )->as_string(indent => 4),
+		0\.0 0\.2 0\.7 0\.01 0\.003
+	/ )->as_string(indent => 4),
 '0\.
 (?:
     0
@@ -238,120 +238,120 @@ is( Regexp::Assemble->new->debug(1)->add( qw/
 , 'pretty 0.0 0.2 0.7 0.01 0.003' );
 
 {
-    my $ra = Regexp::Assemble->new->debug(3);
+	my $ra = Regexp::Assemble->new->debug(3);
 
-    is( $ra->add( qw/ dog darkness doggerel dark / )->as_string,
-        'd(?:ark(?:ness)?|og(?:gerel)?)' );
+	is( $ra->add( qw/ dog darkness doggerel dark / )->as_string,
+		'd(?:ark(?:ness)?|og(?:gerel)?)' );
 
-    is( $ra->add( qw/ limit lit / )->as_string,
-        'l(?:im)?it' );
+	is( $ra->add( qw/ limit lit / )->as_string,
+		'l(?:im)?it' );
 
-    is( $ra->add( qw/ seafood seahorse sea / )->as_string,
-        'sea(?:horse|food)?' );
+	is( $ra->add( qw/ seafood seahorse sea / )->as_string,
+		'sea(?:horse|food)?' );
 
-    is( $ra->add( qw/ bird cat dog elephant fox / )->as_string,
-        '(?:(?:elephan|ca)t|bird|dog|fox)' );
+	is( $ra->add( qw/ bird cat dog elephant fox / )->as_string,
+		'(?:(?:elephan|ca)t|bird|dog|fox)' );
 
-    is( $ra->add( qw/ bit bat sit sat fit fat / )->as_string,
-        '[bfs][ai]t' );
+	is( $ra->add( qw/ bit bat sit sat fit fat / )->as_string,
+		'[bfs][ai]t' );
 
-    is( $ra->add( qw/ split splat slit slat flat flit / )->as_string,
-        '(?:sp?|f)l[ai]t' );
+	is( $ra->add( qw/ split splat slit slat flat flit / )->as_string,
+		'(?:sp?|f)l[ai]t' );
 
-    is( $ra->add( qw/bcktx bckx bdix bdktx bdkx/ )
-        ->as_string, 'b(?:d(?:kt?|i)|ckt?)x',
-        'bcktx bckx bdix bdktx bdkx' );
+	is( $ra->add( qw/bcktx bckx bdix bdktx bdkx/ )
+		->as_string, 'b(?:d(?:kt?|i)|ckt?)x',
+		'bcktx bckx bdix bdktx bdkx' );
 
-    is( $ra->add( qw/gait grit wait writ /)->as_string,
-        '[gw][ar]it' );
+	is( $ra->add( qw/gait grit wait writ /)->as_string,
+		'[gw][ar]it' );
 
-    is( $ra->add( qw/gait grit lit limit /)->as_string,
-        '(?:l(?:im)?|g[ar])it' );
+	is( $ra->add( qw/gait grit lit limit /)->as_string,
+		'(?:l(?:im)?|g[ar])it' );
 
-    is( $ra->add( qw/bait brit frit gait grit tait wait writ /)->as_string,
-        '(?:[bgw][ar]|fr|ta)it' );
+	is( $ra->add( qw/bait brit frit gait grit tait wait writ /)->as_string,
+		'(?:[bgw][ar]|fr|ta)it' );
 
-    is( $ra->add( qw/schoolkids acids acidoids/ )->as_string,
-        '(?:ac(?:ido)?|schoolk)ids' );
+	is( $ra->add( qw/schoolkids acids acidoids/ )->as_string,
+		'(?:ac(?:ido)?|schoolk)ids' );
 
-    is( $ra->add( qw/schoolkids acidoids/ )->as_string,
-        '(?:schoolk|acido)ids' );
+	is( $ra->add( qw/schoolkids acidoids/ )->as_string,
+		'(?:schoolk|acido)ids' );
 
-    is( $ra->add( qw/nonschoolkids nonacidoids/ )->as_string,
-        'non(?:schoolk|acido)ids' );
+	is( $ra->add( qw/nonschoolkids nonacidoids/ )->as_string,
+		'non(?:schoolk|acido)ids' );
 
-    is( $ra->add( qw/schoolkids skids acids acidoids/ )->as_string,
-        '(?:s(?:chool)?k|ac(?:ido)?)ids' );
+	is( $ra->add( qw/schoolkids skids acids acidoids/ )->as_string,
+		'(?:s(?:chool)?k|ac(?:ido)?)ids' );
 
-    is( $ra->add( qw/kids schoolkids skids acids acidoids/ )->as_string,
-        '(?:(?:s(?:chool)?)?k|ac(?:ido)?)ids' );
+	is( $ra->add( qw/kids schoolkids skids acids acidoids/ )->as_string,
+		'(?:(?:s(?:chool)?)?k|ac(?:ido)?)ids' );
 
-    is( $ra->add( qw(abcd abd acd ad bcd bd d) )->as_string,
-        '(?:(?:ab?|b)c?)?d', 'abcd abd acd ad bcd bd d',
-        'indentical nodes in sub_path/insert_node(bifurc)');
+	is( $ra->add( qw(abcd abd acd ad bcd bd d) )->as_string,
+		'(?:(?:ab?|b)c?)?d', 'abcd abd acd ad bcd bd d',
+		'indentical nodes in sub_path/insert_node(bifurc)');
 
-    is( $ra->add( qw(^a$ ^ab$ ^abc$ ^abd$ ^bdef$ ^bdf$ ^bef$ ^bf$) )->as_string,
-        '^(?:a(?:b[cd]?)?|bd?e?f)$', 'fused node');
+	is( $ra->add( qw(^a$ ^ab$ ^abc$ ^abd$ ^bdef$ ^bdf$ ^bef$ ^bf$) )->as_string,
+		'^(?:a(?:b[cd]?)?|bd?e?f)$', 'fused node');
 
-    is( $ra->add(qw[bait brit frit gait grit tait wait writ])->as_string,
-        '(?:[bgw][ar]|fr|ta)it', 'after _insert_path()');
+	is( $ra->add(qw[bait brit frit gait grit tait wait writ])->as_string,
+		'(?:[bgw][ar]|fr|ta)it', 'after _insert_path()');
 
-    is( $ra->add(qw(0 1 10 100))->as_string,
-        '(?:1(?:0?0)?|0)', '_scan_node slid' );
+	is( $ra->add(qw(0 1 10 100))->as_string,
+		'(?:1(?:0?0)?|0)', '_scan_node slid' );
 
-    is( $ra->add( qw(abcd abd bcd bd d) )->as_string,
-        '(?:a?bc?)?d', 'abcd abd bcd bd d' );
+	is( $ra->add( qw(abcd abd bcd bd d) )->as_string,
+		'(?:a?bc?)?d', 'abcd abd bcd bd d' );
 }
 
 SKIP: {
-    skip("perl version too recent ($]), 5.012+ max", 2) if $PERL_VERSION_TOO_HIGH;
-    {
-        my $r = Regexp::Assemble->new->debug(8)->add(qw(this that));
-        my $re = $r->re;
-        is( $re, '(?-xism:th(?:at|is))', 'time debug' );
-    }
+	skip("perl version too recent ($]), 5.012+ max", 2) if $PERL_VERSION_TOO_HIGH;
+	{
+		my $r = Regexp::Assemble->new->debug(8)->add(qw(this that));
+		my $re = $r->re;
+		is( $re, '(?-xism:th(?:at|is))', 'time debug' );
+	}
 
-    {
-        my $r = Regexp::Assemble->new->add(qw(this that))->debug(8)->add('those');
-        my $re = $r->re;
-        is( $re, '(?-xism:th(?:ose|at|is))', 'deferred time debug' );
-    }
+	{
+		my $r = Regexp::Assemble->new->add(qw(this that))->debug(8)->add('those');
+		my $re = $r->re;
+		is( $re, '(?-xism:th(?:ose|at|is))', 'deferred time debug' );
+	}
 }
 
 {
-    my $r = Regexp::Assemble->new->debug(8)->add(qw(this that those));
-    # sabotage
-    delete $r->{_begin_time};
-    is( $r->as_string, 'th(?:ose|at|is)', 'time debug mangle' );
+	my $r = Regexp::Assemble->new->debug(8)->add(qw(this that those));
+	# sabotage
+	delete $r->{_begin_time};
+	is( $r->as_string, 'th(?:ose|at|is)', 'time debug mangle' );
 
-    # use internal time() instead of Time::HiRes
-    delete $r->{_time_func};
-    $r->{_use_time_hires} = 'more sabotage';
-    $r->reset->add(qw(abc ac));
-    is( $r->as_string, 'ab?c', 'internal time debug' );
+	# use internal time() instead of Time::HiRes
+	delete $r->{_time_func};
+	$r->{_use_time_hires} = 'more sabotage';
+	$r->reset->add(qw(abc ac));
+	is( $r->as_string, 'ab?c', 'internal time debug' );
 }
 
 is_deeply( Regexp::Assemble->new->debug(4)->_fastlex('ab+c{2,4}'),
-    ['a', 'b+', 'c{2,4}'],
-    '_fastlex reg plus min-max'
+	['a', 'b+', 'c{2,4}'],
+	'_fastlex reg plus min-max'
 );
 
 my $x;
 is_deeply( $x = Regexp::Assemble->new->debug(4)->_fastlex('\\d+\\s{3,4}?\\Qa+\\E\\lL\\uu\\Ufo\\E\\Lba\\x40'),
-    ['\\d+', '\\s{3,4}?', 'a', '\\+', qw(l U F O b a @)],
-    '_fastlex backslash'
+	['\\d+', '\\s{3,4}?', 'a', '\\+', qw(l U F O b a @)],
+	'_fastlex backslash'
 ) or diag("@$x");
 
 is_deeply( Regexp::Assemble->new->debug(4)->_fastlex('\\Q\\L\\Ua+\\E\\Ub?\\Ec'),
-    [qw(a \\+ B? c)], '_fastlex in and out of quotemeta'
+	[qw(a \\+ B? c)], '_fastlex in and out of quotemeta'
 );
 
 is_deeply( $x = Regexp::Assemble->new->debug(4)->_fastlex('\\bw[0-5]*\\\\(?:x|y){,5}?\\'),
-    [qw(\\b w [0-5]* \\\\), '(?:x|y){,5}?'], '_fastlex more metachars'
+	[qw(\\b w [0-5]* \\\\), '(?:x|y){,5}?'], '_fastlex more metachars'
 ) or diag("@$x");
 
 is_deeply( $x = Regexp::Assemble->new(debug => 4)->_fastlex('\\cG\\007'),
-    [qw(\\cG \\cG)], '_fastlex backslash misc'
+	[qw(\\cG \\cG)], '_fastlex backslash misc'
 ) or diag("@$x");
 
 is( $_, $fixed, '$_ has not been altered' );

--- a/t/10_perl514.t
+++ b/t/10_perl514.t
@@ -9,10 +9,10 @@ use strict;
 
 use Test::More;
 if ($] < 5.013) {
-    plan skip_all => 'Irrelevant below perl <= 5.12';
+	plan skip_all => 'Irrelevant below perl <= 5.12';
 }
 else {
-    plan tests => 3;
+	plan tests => 3;
 }
 
 
@@ -22,15 +22,15 @@ my $fixed = 'The scalar remains the same';
 $_ = $fixed;
 
 {
-    my $r = Regexp::Assemble->new->debug(8)->add(qw(this that));
-    my $re = $r->re;
-    is( $re, '(?^:th(?:at|is))', 'time debug' );
+	my $r = Regexp::Assemble->new->debug(8)->add(qw(this that));
+	my $re = $r->re;
+	is( $re, '(?^:th(?:at|is))', 'time debug' );
 }
 
 {
-    my $r = Regexp::Assemble->new->add(qw(this that))->debug(8)->add('those');
-    my $re = $r->re;
-    is( $re, '(?^:th(?:ose|at|is))', 'deferred time debug' );
+	my $r = Regexp::Assemble->new->add(qw(this that))->debug(8)->add('those');
+	my $re = $r->re;
+	is( $re, '(?^:th(?:ose|at|is))', 'deferred time debug' );
 }
 
 


### PR DESCRIPTION
Ron, thanks for this module, which I have recently started using!  I was looking at the source and noticed some whitespace inconsistencies.  This commit has no functional changes, and all tests pass.  Thanks for considering this PR!

Modifications:
- Convert the few tab indents into space indents, except in Makefiles
- Add a .editorconfig file to configure supported editors for space indents (except Makefile*) (I am an EditorConfig developer)
- Format recent Changes entries to match the format of earlier entries (four-space indents)
- Word-wrap Changes at 80 columns
- Regenerate Changelog.ini
- Add some common temporary-file patterns to .gitignore