### PR TITLE
fix exit status

### DIFF
--- a/examples/assemble
+++ b/examples/assemble
@@ -79,7 +79,7 @@ if( $opt{t} ) {
 		++$error;
 	}
 	close IN;
-	exit $error ? 1 : 0;
+	exit($error ? 1 : 0);
 }
 
 =head1 NAME


### PR DESCRIPTION
`exit` has higher precedence than `?:`, so `exit $error ? 1 : 0` parses as `(exit $error) ? 1 : 0`, which is not what was intended.